### PR TITLE
Phase 1: infra-domain — domain account, data product, monitoring

### DIFF
--- a/infra/environments/domain-sales/backend.tf
+++ b/infra/environments/domain-sales/backend.tf
@@ -1,0 +1,26 @@
+##############################################################################
+# domain-sales/backend.tf
+#
+# S3 backend for domain-sales Terraform state.
+# Separate from central backend — isolated state per environment.
+# SSE-KMS encrypted, DynamoDB locking enabled.
+#
+# IMPORTANT: The S3 bucket and DynamoDB table must be provisioned before
+# running `terraform init`. For initial setup, use `terraform init -backend=false`
+# or provision the backend resources manually.
+##############################################################################
+
+data "aws_caller_identity" "current" {}
+
+terraform {
+  backend "s3" {
+    # Bucket and table must be provisioned before terraform init.
+    # Uncomment and fill in after provisioning the backend:
+    # bucket         = "data-meshy-tfstate-domain-sales-{ACCOUNT_ID}"
+    # key            = "domain-sales/terraform.tfstate"
+    # region         = "us-east-1"
+    # encrypt        = true
+    # kms_key_id     = "alias/mesh-sales"
+    # dynamodb_table = "data-meshy-tflock-domain-sales"
+  }
+}

--- a/infra/environments/domain-sales/main.tf
+++ b/infra/environments/domain-sales/main.tf
@@ -1,0 +1,130 @@
+##############################################################################
+# domain-sales/main.tf
+#
+# Sales domain environment — instantiates all 3 modules:
+#   1. domain-account  — S3, IAM, Glue Catalog, Lake Formation, EventBridge
+#   2. data-product    — Iceberg table, DQ ruleset, Step Functions, catalog entry
+#   3. monitoring      — CloudWatch alarms, log groups, AWS Budgets
+#
+# Cross-account provider configuration: assumes a role in the sales account
+# from the orchestrating environment (central account or local dev).
+##############################################################################
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30.0"
+    }
+  }
+}
+
+##############################################################################
+# Provider configuration
+# For portfolio deployment: use the default provider with the target account
+# credentials (via SSO profile, assumed role, or environment variables).
+# For production multi-account: configure a provider alias assuming a role
+# in the sales account from the central account.
+##############################################################################
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "data-meshy"
+      ManagedBy   = "terraform"
+      Environment = var.environment
+      Domain      = var.domain
+    }
+  }
+}
+
+##############################################################################
+# Module: domain-account
+##############################################################################
+
+module "domain_account" {
+  source = "../../modules/domain-account"
+
+  domain                = var.domain
+  environment           = var.environment
+  aws_org_id            = var.aws_org_id
+  central_account_id    = var.central_account_id
+  central_event_bus_arn = var.central_event_bus_arn
+
+  mesh_catalog_writer_role_arn = var.mesh_catalog_writer_role_arn
+
+  tags = var.tags
+}
+
+##############################################################################
+# Module: data-product (customer_orders)
+##############################################################################
+
+module "data_product" {
+  source = "../../modules/data-product"
+
+  domain        = var.domain
+  product_name  = var.product_name
+  environment   = var.environment
+  aws_region    = var.aws_region
+
+  # Consumed from domain-account module outputs
+  raw_bucket_name              = module.domain_account.raw_bucket_name
+  silver_bucket_name           = module.domain_account.silver_bucket_name
+  gold_bucket_name             = module.domain_account.gold_bucket_name
+  glue_catalog_db_raw          = module.domain_account.glue_catalog_db_raw
+  glue_catalog_db_silver       = module.domain_account.glue_catalog_db_silver
+  glue_catalog_db_gold         = module.domain_account.glue_catalog_db_gold
+  glue_job_execution_role_arn  = module.domain_account.glue_job_execution_role_arn
+  mesh_event_role_arn          = module.domain_account.mesh_event_role_arn
+  domain_kms_key_arn           = module.domain_account.domain_kms_key_arn
+  domain_event_bus_arn         = module.domain_account.domain_event_bus_arn
+
+  # Consumed from governance module outputs (Stream 1)
+  central_event_bus_arn        = var.central_event_bus_arn
+  mesh_products_table_name     = "mesh-products"
+  mesh_pipeline_locks_table_name = "mesh-pipeline-locks"
+  mesh_audit_log_table_name    = "mesh-audit-log"
+
+  # Product spec
+  schema_columns      = var.schema_columns
+  partition_keys      = var.partition_keys
+  classification      = var.classification
+  pii                 = var.pii
+  dq_rules            = var.dq_rules
+  owner               = var.owner
+  description         = var.description
+  schema_version      = var.schema_version
+  sla_refresh_frequency = var.sla_refresh_frequency
+  sla_availability    = var.sla_availability
+  source_name         = var.source_name
+
+  tags = var.tags
+}
+
+##############################################################################
+# Module: monitoring
+##############################################################################
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  domain                = var.domain
+  environment           = var.environment
+  aws_region            = var.aws_region
+  alarm_notification_arn = var.quality_alert_sns_topic_arn
+
+  lambda_function_names = var.lambda_function_names
+  dlq_queue_arns        = var.dlq_queue_arns
+
+  state_machine_arn = module.data_product.state_machine_arn
+  glue_job_names    = var.glue_job_names
+
+  budget_thresholds      = var.budget_thresholds
+  budget_email_recipients = var.budget_email_recipients
+
+  tags = var.tags
+}

--- a/infra/environments/domain-sales/terraform.tfvars
+++ b/infra/environments/domain-sales/terraform.tfvars
@@ -1,0 +1,105 @@
+##############################################################################
+# domain-sales/terraform.tfvars
+#
+# Variable values for the Sales domain environment.
+# Instantiates: domain-account, data-product, monitoring modules.
+##############################################################################
+
+# ── Domain configuration ──────────────────────────────────────────────────────
+
+domain      = "sales"
+environment = "dev"
+aws_region  = "us-east-1"
+
+# ── Cross-account references (from governance module / Stream 1) ─────────────
+# These values must be updated with actual account IDs and ARNs after
+# the central governance account is provisioned (Stream 1).
+
+aws_org_id                = "o-xxxxxxxxxx"    # Replace with actual Organization ID
+central_account_id        = "000000000000"    # Replace with actual central account ID
+central_event_bus_arn     = "arn:aws:events:us-east-1:000000000000:event-bus/mesh-central-bus"
+mesh_catalog_writer_role_arn = "arn:aws:iam::000000000000:role/MeshCatalogWriterRole"
+quality_alert_sns_topic_arn  = "arn:aws:sns:us-east-1:000000000000:mesh-quality-alerts"
+
+# ── Data Product: customer_orders ─────────────────────────────────────────────
+
+product_name        = "customer_orders"
+description         = "Sales domain customer orders data product — order line items with product and customer details."
+owner               = "sales-data-team@example.com"
+schema_version      = 1
+classification      = "internal"
+pii                 = true
+
+sla_refresh_frequency = "daily"
+sla_availability      = "99.9"
+
+source_name = "erp_orders"
+
+# Schema columns for customer_orders Iceberg table
+schema_columns = [
+  { name = "order_id",          type = "bigint",        comment = "Unique order identifier (PK)" },
+  { name = "order_line_id",     type = "int",           comment = "Line item number within the order" },
+  { name = "customer_id",       type = "bigint",        comment = "Customer identifier (FK)" },
+  { name = "product_id",        type = "bigint",        comment = "Product identifier (FK)" },
+  { name = "order_date",        type = "timestamp",     comment = "Date and time the order was placed" },
+  { name = "ship_date",         type = "timestamp",     comment = "Date the order was shipped" },
+  { name = "quantity",          type = "int",           comment = "Quantity ordered" },
+  { name = "unit_price",        type = "decimal(10,2)", comment = "Price per unit at time of sale" },
+  { name = "discount_pct",      type = "decimal(5,2)",  comment = "Discount percentage applied" },
+  { name = "total_amount",      type = "decimal(12,2)", comment = "Line total after discount" },
+  { name = "currency_code",     type = "string",        comment = "ISO 4217 currency code" },
+  { name = "order_status",      type = "string",        comment = "Order status: pending/processed/shipped/delivered/cancelled" },
+  { name = "payment_method",    type = "string",        comment = "Payment method: card/bank_transfer/invoice" },
+  { name = "shipping_address",  type = "string",        comment = "Shipping address (PII)" },
+  { name = "customer_email",    type = "string",        comment = "Customer email address (PII)" },
+  { name = "region",            type = "string",        comment = "Sales region" },
+  { name = "sales_rep_id",      type = "bigint",        comment = "Sales representative identifier" },
+  { name = "created_at",        type = "timestamp",     comment = "Record creation timestamp" },
+  { name = "updated_at",        type = "timestamp",     comment = "Record last update timestamp" }
+]
+
+partition_keys = ["region"]
+
+# Data Quality rules (DQDL) for customer_orders
+dq_rules = [
+  "Rules = [",
+  "  ColumnValues \"order_id\" > 0",
+  "  ColumnValues \"customer_id\" > 0",
+  "  ColumnValues \"product_id\" > 0",
+  "  ColumnValues \"quantity\" > 0",
+  "  ColumnValues \"unit_price\" >= 0",
+  "  ColumnValues \"total_amount\" >= 0",
+  "  ColumnValues \"discount_pct\" >= 0",
+  "  ColumnValues \"discount_pct\" <= 100",
+  "  Completeness \"order_id\" > 0.99",
+  "  Completeness \"customer_id\" > 0.99",
+  "  Completeness \"order_date\" > 0.99",
+  "  Completeness \"total_amount\" > 0.99",
+  "  Uniqueness \"order_id\" > 0.99",
+  "  IsUnique \"order_line_id\" AND \"order_id\"",
+  "  ColumnLength \"currency_code\" = 3",
+  "  ColumnValues \"order_status\" IN (\"pending\", \"processed\", \"shipped\", \"delivered\", \"cancelled\")",
+  "]"
+]
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+
+lambda_function_names = []
+
+dlq_queue_arns = {}
+
+glue_job_names = [
+  "raw_ingestion",
+  "silver_transform",
+  "gold_aggregate",
+  "iceberg_maintenance"
+]
+
+budget_thresholds    = [20, 50, 100]
+budget_email_recipients = []
+
+# ── Additional tags ───────────────────────────────────────────────────────────
+
+tags = {
+  Layer = "domain"
+}

--- a/infra/environments/domain-sales/variables.tf
+++ b/infra/environments/domain-sales/variables.tf
@@ -1,0 +1,165 @@
+##############################################################################
+# domain-sales/variables.tf
+#
+# Variable declarations for the Sales domain environment.
+# Values are set in terraform.tfvars.
+##############################################################################
+
+variable "domain" {
+  description = "Domain name."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment."
+  type        = string
+  default     = "dev"
+}
+
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}
+
+# ── Cross-account references ─────────────────────────────────────────────────
+
+variable "aws_org_id" {
+  description = "AWS Organization ID."
+  type        = string
+}
+
+variable "central_account_id" {
+  description = "Account ID of the central governance account."
+  type        = string
+}
+
+variable "central_event_bus_arn" {
+  description = "ARN of the central EventBridge bus."
+  type        = string
+}
+
+variable "mesh_catalog_writer_role_arn" {
+  description = "ARN of MeshCatalogWriterRole in central account."
+  type        = string
+}
+
+variable "quality_alert_sns_topic_arn" {
+  description = "ARN of the quality alert SNS topic in central account."
+  type        = string
+}
+
+# ── Data Product: customer_orders ─────────────────────────────────────────────
+
+variable "product_name" {
+  description = "Data product name."
+  type        = string
+}
+
+variable "description" {
+  description = "Product description."
+  type        = string
+  default     = ""
+}
+
+variable "owner" {
+  description = "Product owner email or team."
+  type        = string
+}
+
+variable "schema_version" {
+  description = "Schema version (monotonically increasing)."
+  type        = number
+  default     = 1
+}
+
+variable "classification" {
+  description = "LF-Tag classification."
+  type        = string
+  default     = "internal"
+}
+
+variable "pii" {
+  description = "Whether the product contains PII."
+  type        = bool
+  default     = false
+}
+
+variable "sla_refresh_frequency" {
+  description = "SLA refresh frequency."
+  type        = string
+  default     = "daily"
+}
+
+variable "sla_availability" {
+  description = "SLA availability target."
+  type        = string
+  default     = "99.9"
+}
+
+variable "source_name" {
+  description = "Source system identifier for Secrets Manager."
+  type        = string
+  default     = "default"
+}
+
+variable "schema_columns" {
+  description = "Iceberg table column definitions."
+  type = list(object({
+    name    = string
+    type    = string
+    comment = optional(string, "")
+  }))
+}
+
+variable "partition_keys" {
+  description = "Partition key column names."
+  type        = list(string)
+  default     = []
+}
+
+variable "dq_rules" {
+  description = "DQDL quality rule strings."
+  type        = list(string)
+  default     = []
+}
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+
+variable "lambda_function_names" {
+  description = "Lambda function names to monitor."
+  type        = list(string)
+  default     = []
+}
+
+variable "dlq_queue_arns" {
+  description = "DLQ queue name -> ARN mapping."
+  type        = map(string)
+  default     = {}
+}
+
+variable "glue_job_names" {
+  description = "Glue job names to monitor."
+  type        = list(string)
+  default     = []
+}
+
+variable "budget_thresholds" {
+  description = "Budget threshold amounts (USD)."
+  type        = list(number)
+  default     = [20, 50, 100]
+}
+
+variable "budget_email_recipients" {
+  description = "Email addresses for budget alerts."
+  type        = list(string)
+  default     = []
+}
+
+# ── Tags ──────────────────────────────────────────────────────────────────────
+
+variable "tags" {
+  description = "Additional tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/data-product/catalog.tf
+++ b/infra/modules/data-product/catalog.tf
@@ -1,0 +1,73 @@
+##############################################################################
+# data-product/catalog.tf
+#
+# Registers the data product in the central DynamoDB mesh-products table.
+# PK: {domain}#{product_name}, initial status = PROVISIONED.
+#
+# Note: This resource uses aws_dynamodb_table_item which writes directly to
+# the table. In production, the central Lambda handler (Stream 3) writes the
+# catalog entry via ProductCreated event. This Terraform resource creates the
+# initial entry so the product is visible in the catalog immediately after
+# infrastructure provisioning.
+#
+# The DynamoDB table itself is created in the central governance account
+# (Stream 1). This resource assumes cross-account DynamoDB access or that
+# Terraform is run with credentials that have write access to the table.
+# For Phase 1 portfolio, the same Terraform state manages both accounts.
+##############################################################################
+
+resource "aws_dynamodb_table_item" "product_catalog_entry" {
+  table_name = var.mesh_products_table_name
+  hash_key   = "domain#product_name"
+
+  item = jsonencode({
+    "domain#product_name" = {
+      S = local.product_id
+    }
+    "domain" = {
+      S = var.domain
+    }
+    "product_name" = {
+      S = var.product_name
+    }
+    "status" = {
+      S = "PROVISIONED"
+    }
+    "schema_version" = {
+      N = tostring(var.schema_version)
+    }
+    "owner" = {
+      S = var.owner
+    }
+    "description" = {
+      S = var.description
+    }
+    "classification" = {
+      S = var.classification
+    }
+    "pii" = {
+      BOOL = var.pii
+    }
+    "sla_refresh_frequency" = {
+      S = var.sla_refresh_frequency
+    }
+    "sla_availability" = {
+      S = var.sla_availability
+    }
+    "gold_bucket" = {
+      S = var.gold_bucket_name
+    }
+    "gold_db" = {
+      S = var.glue_catalog_db_gold
+    }
+    "table_name" = {
+      S = var.product_name
+    }
+    "quality_ruleset_name" = {
+      S = "${var.domain}_${var.product_name}_dq"
+    }
+    "created_at" = {
+      S = "PROVISIONED_BY_TERRAFORM"
+    }
+  })
+}

--- a/infra/modules/data-product/iceberg.tf
+++ b/infra/modules/data-product/iceberg.tf
@@ -1,0 +1,92 @@
+##############################################################################
+# data-product/iceberg.tf
+#
+# Iceberg table registration in Glue Data Catalog (gold database).
+# LF-Tags applied: classification, pii, domain.
+##############################################################################
+
+##############################################################################
+# Glue Catalog Table — Iceberg format in the gold database
+##############################################################################
+
+resource "aws_glue_catalog_table" "product" {
+  name          = var.product_name
+  database_name = var.glue_catalog_db_gold
+  description   = var.description
+
+  table_type = "EXTERNAL_TABLE"
+
+  open_table_format_input {
+    iceberg_input {
+      metadata_operation = "CREATE"
+      version            = "2"
+    }
+  }
+
+  storage_descriptor {
+    location = "s3://${var.gold_bucket_name}/${var.domain}/${var.product_name}/"
+
+    dynamic "columns" {
+      for_each = var.schema_columns
+      content {
+        name    = columns.value.name
+        type    = columns.value.type
+        comment = columns.value.comment
+      }
+    }
+
+    input_format  = "org.apache.iceberg.mr.hive.HiveIcebergInputFormat"
+    output_format = "org.apache.iceberg.mr.hive.HiveIcebergOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.iceberg.mr.hive.HiveIcebergSerDe"
+    }
+  }
+
+  dynamic "partition_keys" {
+    for_each = var.partition_keys
+    content {
+      name = partition_keys.value
+      type = "string"
+    }
+  }
+
+  parameters = {
+    "table_type"       = "ICEBERG"
+    "metadata_location" = "s3://${var.gold_bucket_name}/${var.domain}/${var.product_name}/metadata/"
+    "classification"   = var.classification
+    "schema_version"   = tostring(var.schema_version)
+    "product_id"       = local.product_id
+    "owner"            = var.owner
+  }
+}
+
+##############################################################################
+# LF-Tags applied to the Iceberg table
+##############################################################################
+
+resource "aws_lakeformation_resource_lf_tags" "product_table" {
+  database {
+    name = var.glue_catalog_db_gold
+  }
+
+  table {
+    database_name = var.glue_catalog_db_gold
+    name          = aws_glue_catalog_table.product.name
+  }
+
+  lf_tag {
+    key   = "domain"
+    value = var.domain
+  }
+
+  lf_tag {
+    key   = "classification"
+    value = var.classification
+  }
+
+  lf_tag {
+    key   = "pii"
+    value = tostring(var.pii)
+  }
+}

--- a/infra/modules/data-product/main.tf
+++ b/infra/modules/data-product/main.tf
@@ -1,0 +1,68 @@
+##############################################################################
+# data-product/main.tf
+#
+# Orchestration file for the data-product module.
+# Creates: Secrets Manager placeholder for source credentials.
+# Iceberg table -> iceberg.tf | DQ ruleset -> quality.tf
+# Step Functions SM -> step_functions.tf | Catalog entry -> catalog.tf
+##############################################################################
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30.0"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
+
+  mandatory_tags = {
+    Project     = "data-meshy"
+    ManagedBy   = "terraform"
+    Environment = var.environment
+    Domain      = var.domain
+  }
+
+  tags = merge(local.mandatory_tags, var.tags)
+
+  # Canonical product ID used as DynamoDB PK
+  product_id = "${var.domain}#${var.product_name}"
+}
+
+##############################################################################
+# Secrets Manager — Placeholder for source database credentials
+# The ARN is referenced in product.yaml under lineage.sources[].credentials_secret_arn
+# Rotation: 90 days
+##############################################################################
+
+resource "aws_secretsmanager_secret" "source_credentials" {
+  name        = "${var.domain}/${var.product_name}/${var.source_name}-credentials"
+  description = "Source database credentials for ${var.domain}/${var.product_name} Glue ingestion job."
+  kms_key_id  = var.domain_kms_key_arn
+
+  recovery_window_in_days = 30
+
+  tags = merge(local.tags, { ProductName = var.product_name })
+}
+
+resource "aws_secretsmanager_secret_rotation" "source_credentials" {
+  secret_id           = aws_secretsmanager_secret.source_credentials.id
+  rotation_lambda_arn = null # Placeholder: populate with rotation Lambda ARN in production
+
+  rotation_rules {
+    automatically_after_days = 90
+  }
+
+  # lifecycle ignore since rotation Lambda ARN is not wired in Phase 1
+  lifecycle {
+    ignore_changes = [rotation_lambda_arn]
+  }
+}

--- a/infra/modules/data-product/outputs.tf
+++ b/infra/modules/data-product/outputs.tf
@@ -1,0 +1,99 @@
+##############################################################################
+# data-product/outputs.tf
+#
+# Output names match the shared contract in plan/phases/phase-1/README.md.
+# Consumed by Stream 3 (pipeline-events) and Stream 4 (cli-ci-example).
+# DO NOT rename without updating the README contract.
+##############################################################################
+
+# ── S3 bucket names ──────────────────────────────────────────────────────────
+
+output "raw_bucket_name" {
+  description = "S3 bucket name for the raw (Bronze) layer."
+  value       = var.raw_bucket_name
+}
+
+output "silver_bucket_name" {
+  description = "S3 bucket name for the silver (Validated) layer."
+  value       = var.silver_bucket_name
+}
+
+output "gold_bucket_name" {
+  description = "S3 bucket name for the gold (Data Product) layer."
+  value       = var.gold_bucket_name
+}
+
+# ── Glue catalog database names ──────────────────────────────────────────────
+
+output "glue_catalog_db_raw" {
+  description = "Glue Data Catalog database name for the raw layer."
+  value       = var.glue_catalog_db_raw
+}
+
+output "glue_catalog_db_silver" {
+  description = "Glue Data Catalog database name for the silver layer."
+  value       = var.glue_catalog_db_silver
+}
+
+output "glue_catalog_db_gold" {
+  description = "Glue Data Catalog database name for the gold layer."
+  value       = var.glue_catalog_db_gold
+}
+
+# ── IAM role ARNs ────────────────────────────────────────────────────────────
+
+output "glue_job_execution_role_arn" {
+  description = "ARN of GlueJobExecutionRole — passed as execution role for Glue jobs."
+  value       = var.glue_job_execution_role_arn
+}
+
+output "mesh_event_role_arn" {
+  description = "ARN of MeshEventRole — used by Lambda/Step Functions to PutEvents on the central bus."
+  value       = var.mesh_event_role_arn
+}
+
+# ── EventBridge ──────────────────────────────────────────────────────────────
+
+output "domain_event_bus_arn" {
+  description = "ARN of the domain EventBridge bus (mesh-domain-bus)."
+  value       = var.domain_event_bus_arn
+}
+
+# ── KMS ──────────────────────────────────────────────────────────────────────
+
+output "domain_kms_key_arn" {
+  description = "ARN of the domain KMS CMK (alias/mesh-{domain}). Used for S3 encryption context."
+  value       = var.domain_kms_key_arn
+}
+
+# ── Product-specific outputs ─────────────────────────────────────────────────
+
+output "product_id" {
+  description = "Canonical product ID ({domain}#{product_name}) used as DynamoDB PK."
+  value       = local.product_id
+}
+
+output "quality_ruleset_name" {
+  description = "Glue Data Quality ruleset name ({domain}_{product_name}_dq)."
+  value       = aws_glue_data_quality_ruleset.product.name
+}
+
+output "state_machine_arn" {
+  description = "ARN of the Step Functions medallion pipeline state machine."
+  value       = aws_sfn_state_machine.medallion_pipeline.arn
+}
+
+output "state_machine_name" {
+  description = "Name of the Step Functions medallion pipeline state machine."
+  value       = aws_sfn_state_machine.medallion_pipeline.name
+}
+
+output "source_credentials_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding source DB credentials."
+  value       = aws_secretsmanager_secret.source_credentials.arn
+}
+
+output "iceberg_table_arn" {
+  description = "ARN of the Glue Catalog table (Iceberg) for this data product."
+  value       = aws_glue_catalog_table.product.arn
+}

--- a/infra/modules/data-product/quality.tf
+++ b/infra/modules/data-product/quality.tf
@@ -1,0 +1,20 @@
+##############################################################################
+# data-product/quality.tf
+#
+# Glue Data Quality ruleset attached to the gold Iceberg table.
+# Rules are sourced from product.yaml quality.rules — passed as a variable.
+# Ruleset name follows the naming convention: {domain}_{product_name}_dq
+##############################################################################
+
+resource "aws_glue_data_quality_ruleset" "product" {
+  name = "${var.domain}_${var.product_name}_dq"
+
+  target_table {
+    database_name = var.glue_catalog_db_gold
+    table_name    = aws_glue_catalog_table.product.name
+  }
+
+  ruleset = join("\n", var.dq_rules)
+
+  tags = merge(local.tags, { ProductName = var.product_name })
+}

--- a/infra/modules/data-product/step_functions.tf
+++ b/infra/modules/data-product/step_functions.tf
@@ -1,0 +1,62 @@
+##############################################################################
+# data-product/step_functions.tf
+#
+# Step Functions state machine for the medallion pipeline:
+#   Raw Ingestion -> Silver Transform -> Gold Aggregate -> Schema Validate
+#   -> Quality Check -> Publish/Alert -> Release Lock -> Iceberg Maintenance
+#
+# ASL definition sourced from templates/step_functions/medallion_pipeline.asl.json.
+# Execution role: MeshEventRole (PutEvents on central bus) + Glue start job permissions.
+# State machine name: {domain}-{product_name}-pipeline
+##############################################################################
+
+##############################################################################
+# CloudWatch Log Group for Step Functions execution logs
+##############################################################################
+
+resource "aws_cloudwatch_log_group" "sfn_pipeline" {
+  name              = "/data-meshy/${var.domain}/${var.product_name}/pipeline"
+  retention_in_days = 30
+
+  tags = merge(local.tags, {
+    Name        = "${var.domain}-${var.product_name}-pipeline-logs"
+    ProductName = var.product_name
+  })
+}
+
+##############################################################################
+# Step Functions State Machine
+##############################################################################
+
+resource "aws_sfn_state_machine" "medallion_pipeline" {
+  name     = "${var.domain}-${var.product_name}-pipeline"
+  role_arn = var.mesh_event_role_arn
+
+  # ASL definition from the shared template (written by Stream 3).
+  # Falls back to an inline definition if the file does not yet exist.
+  definition = fileexists(var.medallion_pipeline_asl_path) ? templatefile(var.medallion_pipeline_asl_path, {}) : jsonencode({
+    Comment       = "Data Meshy — Medallion Pipeline for ${var.domain}/${var.product_name}. Placeholder: replace with full ASL from templates/step_functions/medallion_pipeline.asl.json."
+    StartAt       = "PlaceholderSucceed"
+    TimeoutSeconds = 7200
+    States = {
+      PlaceholderSucceed = {
+        Type = "Succeed"
+      }
+    }
+  })
+
+  logging_configuration {
+    log_destination        = "${aws_cloudwatch_log_group.sfn_pipeline.arn}:*"
+    include_execution_data = true
+    level                  = "ALL"
+  }
+
+  tracing_configuration {
+    enabled = true
+  }
+
+  tags = merge(local.tags, {
+    Name        = "${var.domain}-${var.product_name}-pipeline"
+    ProductName = var.product_name
+  })
+}

--- a/infra/modules/data-product/variables.tf
+++ b/infra/modules/data-product/variables.tf
@@ -1,0 +1,198 @@
+variable "domain" {
+  description = "Domain name (e.g. sales). Must match the domain-account module domain."
+  type        = string
+}
+
+variable "product_name" {
+  description = "Data product name in snake_case (e.g. customer_orders)."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9_]*$", var.product_name))
+    error_message = "product_name must be lowercase snake_case starting with a letter."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)."
+  type        = string
+  default     = "dev"
+}
+
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}
+
+# ── Consumed from domain-account module outputs ──────────────────────────────
+
+variable "raw_bucket_name" {
+  description = "S3 bucket name for the raw layer (from domain-account output)."
+  type        = string
+}
+
+variable "silver_bucket_name" {
+  description = "S3 bucket name for the silver layer (from domain-account output)."
+  type        = string
+}
+
+variable "gold_bucket_name" {
+  description = "S3 bucket name for the gold layer (from domain-account output)."
+  type        = string
+}
+
+variable "glue_catalog_db_raw" {
+  description = "Glue catalog DB name for the raw layer (from domain-account output)."
+  type        = string
+}
+
+variable "glue_catalog_db_silver" {
+  description = "Glue catalog DB name for the silver layer (from domain-account output)."
+  type        = string
+}
+
+variable "glue_catalog_db_gold" {
+  description = "Glue catalog DB name for the gold layer (from domain-account output)."
+  type        = string
+}
+
+variable "glue_job_execution_role_arn" {
+  description = "ARN of GlueJobExecutionRole (from domain-account output)."
+  type        = string
+}
+
+variable "mesh_event_role_arn" {
+  description = "ARN of MeshEventRole — Step Functions execution role (from domain-account output)."
+  type        = string
+}
+
+variable "domain_kms_key_arn" {
+  description = "ARN of domain KMS CMK (from domain-account output)."
+  type        = string
+}
+
+variable "domain_event_bus_arn" {
+  description = "ARN of domain EventBridge bus (from domain-account output)."
+  type        = string
+}
+
+# ── Consumed from governance module outputs (Stream 1) ───────────────────────
+
+variable "mesh_products_table_name" {
+  description = "DynamoDB table name for mesh-products catalog (from governance module output)."
+  type        = string
+  default     = "mesh-products"
+}
+
+variable "mesh_pipeline_locks_table_name" {
+  description = "DynamoDB table name for pipeline locks (from governance module output)."
+  type        = string
+  default     = "mesh-pipeline-locks"
+}
+
+variable "mesh_audit_log_table_name" {
+  description = "DynamoDB table name for audit log (from governance module output)."
+  type        = string
+  default     = "mesh-audit-log"
+}
+
+variable "central_event_bus_arn" {
+  description = "ARN of the central EventBridge bus (from governance module output)."
+  type        = string
+}
+
+# ── Iceberg table schema (from product.yaml) ─────────────────────────────────
+
+variable "schema_columns" {
+  description = "List of column definitions for the Iceberg table. Each element: {name, type, comment}."
+  type = list(object({
+    name    = string
+    type    = string
+    comment = optional(string, "")
+  }))
+}
+
+variable "partition_keys" {
+  description = "List of partition key column names (subset of schema_columns)."
+  type        = list(string)
+  default     = []
+}
+
+variable "classification" {
+  description = "LF-Tag classification value (public/internal/confidential/restricted)."
+  type        = string
+  default     = "internal"
+
+  validation {
+    condition     = contains(["public", "internal", "confidential", "restricted"], var.classification)
+    error_message = "classification must be one of: public, internal, confidential, restricted."
+  }
+}
+
+variable "pii" {
+  description = "Whether this data product contains PII data. Used for LF-Tag pii=true/false."
+  type        = bool
+  default     = false
+}
+
+# ── Data quality (from product.yaml quality.rules) ───────────────────────────
+
+variable "dq_rules" {
+  description = "List of DQDL rule strings from product.yaml quality.rules section."
+  type        = list(string)
+  default     = []
+}
+
+# ── Product metadata (from product.yaml) ─────────────────────────────────────
+
+variable "owner" {
+  description = "Data product owner email or team name."
+  type        = string
+}
+
+variable "description" {
+  description = "Short description of the data product."
+  type        = string
+  default     = ""
+}
+
+variable "schema_version" {
+  description = "Schema version integer, monotonically increasing."
+  type        = number
+  default     = 1
+}
+
+variable "sla_refresh_frequency" {
+  description = "SLA refresh frequency string (e.g. daily, hourly, weekly)."
+  type        = string
+  default     = "daily"
+}
+
+variable "sla_availability" {
+  description = "SLA availability target as a string (e.g. 99.9)."
+  type        = string
+  default     = "99.9"
+}
+
+# ── Step Functions ASL path ───────────────────────────────────────────────────
+
+variable "medallion_pipeline_asl_path" {
+  description = "Absolute or relative path to templates/step_functions/medallion_pipeline.asl.json (written by Stream 3). Must be set by the calling environment."
+  type        = string
+  default     = ""
+}
+
+# ── Source credentials secret ─────────────────────────────────────────────────
+
+variable "source_name" {
+  description = "Identifier for the source system (used in Secrets Manager secret name)."
+  type        = string
+  default     = "default"
+}
+
+variable "tags" {
+  description = "Additional tags merged with the mandatory set."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/domain-account/eventbridge.tf
+++ b/infra/modules/domain-account/eventbridge.tf
@@ -1,0 +1,169 @@
+##############################################################################
+# domain-account/eventbridge.tf
+#
+# Domain EventBridge bus configuration:
+#   - Custom event bus: mesh-domain-bus
+#   - Resource policy: only allows PutEvents from SAME account
+#     (prevents cross-domain event injection)
+#   - Forwarding rule: source = "datameshy" (NOT datameshy.central) → central bus
+#   - IAM role for the forwarding rule target
+##############################################################################
+
+##############################################################################
+# Domain Event Bus
+##############################################################################
+
+resource "aws_cloudwatch_event_bus" "domain" {
+  name = "mesh-domain-bus"
+  tags = local.tags
+}
+
+##############################################################################
+# Resource Policy — only same-account PutEvents allowed
+# This prevents any other domain account (or external party) from injecting
+# events into this domain's bus.
+##############################################################################
+
+resource "aws_cloudwatch_event_bus_policy" "domain" {
+  event_bus_name = aws_cloudwatch_event_bus.domain.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSameAccountPutEvents"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action   = "events:PutEvents"
+        Resource = aws_cloudwatch_event_bus.domain.arn
+      },
+      # Explicitly deny any other principal
+      {
+        Sid       = "DenyAllOtherAccounts"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "events:PutEvents"
+        Resource  = aws_cloudwatch_event_bus.domain.arn
+        Condition = {
+          StringNotEquals = {
+            "aws:PrincipalAccount" = local.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+##############################################################################
+# IAM Role — EventBridge rule → central bus forwarding
+##############################################################################
+
+resource "aws_iam_role" "eventbridge_forwarder" {
+  name        = "${var.domain}-EventBridgeForwarderRole"
+  description = "Allows EventBridge rule to forward events to the central mesh bus."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EventBridgeAssume"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = local.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "eventbridge_forwarder_policy" {
+  name = "${var.domain}-EventBridgeForwarderPolicy"
+  role = aws_iam_role.eventbridge_forwarder.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "PutEventsOnCentralBus"
+        Effect = "Allow"
+        Action = "events:PutEvents"
+        Resource = var.central_event_bus_arn
+      }
+    ]
+  })
+}
+
+##############################################################################
+# Forwarding Rule
+# Pattern: source = "datameshy" (NOT "datameshy.central" — that's reserved
+# for central SFN events and must not originate from domain accounts).
+##############################################################################
+
+resource "aws_cloudwatch_event_rule" "forward_to_central" {
+  name           = "${var.domain}-forward-datameshy-events"
+  description    = "Forward all datameshy events (source=datameshy) from domain bus to central mesh bus."
+  event_bus_name = aws_cloudwatch_event_bus.domain.name
+
+  event_pattern = jsonencode({
+    source = ["datameshy"]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "forward_to_central" {
+  rule           = aws_cloudwatch_event_rule.forward_to_central.name
+  event_bus_name = aws_cloudwatch_event_bus.domain.name
+  target_id      = "ForwardToCentralBus"
+  arn            = var.central_event_bus_arn
+  role_arn       = aws_iam_role.eventbridge_forwarder.arn
+}
+
+##############################################################################
+# Dead-letter queue for the forwarding rule target
+##############################################################################
+
+resource "aws_sqs_queue" "eventbridge_forwarder_dlq" {
+  name                       = "${var.domain}-eventbridge-forward-dlq"
+  message_retention_seconds  = 1209600 # 14 days
+  visibility_timeout_seconds = 60
+
+  kms_master_key_id                 = aws_kms_key.domain.id
+  kms_data_key_reuse_period_seconds = 300
+
+  tags = local.tags
+}
+
+resource "aws_sqs_queue_policy" "eventbridge_forwarder_dlq" {
+  queue_url = aws_sqs_queue.eventbridge_forwarder_dlq.url
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgeSendMessage"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sqs:SendMessage"
+        Resource = aws_sqs_queue.eventbridge_forwarder_dlq.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.forward_to_central.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/infra/modules/domain-account/iam.tf
+++ b/infra/modules/domain-account/iam.tf
@@ -1,0 +1,629 @@
+##############################################################################
+# domain-account/iam.tf
+#
+# IAM roles per domain:
+#   - DomainAdminRole         — full domain access, trust=SSO
+#   - DomainDataEngineerRole  — S3+Glue access, trust=SSO, permission boundary
+#   - DomainConsumerRole      — LF read-only, trust=SSO
+#   - GlueJobExecutionRole    — ETL service role, trust=glue, permission boundary
+#   - MeshEventRole           — PutEvents on central bus, trust=lambda+states
+##############################################################################
+
+##############################################################################
+# Permission Boundary: restrict S3 access to own domain buckets only
+# Applied to GlueJobExecutionRole and DomainDataEngineerRole.
+##############################################################################
+
+resource "aws_iam_policy" "domain_s3_boundary" {
+  name        = "${var.domain}-DomainS3PermissionBoundary"
+  description = "Permission boundary restricting S3 access to ${var.domain} domain buckets only."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowDomainBucketsOnly"
+        Effect = "Allow"
+        Action = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}/*"
+        ]
+      },
+      # Allow all non-S3 actions (so boundary only limits S3 scope)
+      {
+        Sid      = "AllowNonS3Services"
+        Effect   = "Allow"
+        NotAction = "s3:*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+##############################################################################
+# DomainAdminRole
+# Full domain resource access. Cannot modify LF permissions.
+# Trust: SAML/SSO (generic SSO trust — actual federation configured in IAM IC)
+##############################################################################
+
+resource "aws_iam_role" "domain_admin" {
+  name        = "DomainAdminRole"
+  description = "Full domain resource access for ${var.domain} domain admins. Trust: SSO."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSSOAssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${local.account_id}:saml-provider/AWSSSO"
+        }
+        Action = "sts:AssumeRoleWithSAML"
+        Condition = {
+          StringEquals = {
+            "SAML:aud" = "https://signin.aws.amazon.com/saml"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "domain_admin_policy" {
+  name = "${var.domain}-DomainAdminPolicy"
+  role = aws_iam_role.domain_admin.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "FullDomainS3Access"
+        Effect = "Allow"
+        Action = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}/*"
+        ]
+      },
+      {
+        Sid    = "GlueCatalogReadWrite"
+        Effect = "Allow"
+        Action = [
+          "glue:GetDatabase*",
+          "glue:GetTable*",
+          "glue:CreateTable",
+          "glue:UpdateTable",
+          "glue:DeleteTable",
+          "glue:GetJob*",
+          "glue:CreateJob",
+          "glue:UpdateJob",
+          "glue:StartJobRun",
+          "glue:GetCrawler*",
+          "glue:CreateCrawler",
+          "glue:StartCrawler",
+          "glue:GetDataQualityRuleset*",
+          "glue:CreateDataQualityRuleset"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = { "glue:database" = ["${var.domain}_raw", "${var.domain}_silver", "${var.domain}_gold"] }
+        }
+      },
+      {
+        Sid    = "GlueJobAndCrawlerNoCondition"
+        Effect = "Allow"
+        Action = [
+          "glue:GetJob*",
+          "glue:CreateJob",
+          "glue:UpdateJob",
+          "glue:StartJobRun",
+          "glue:ListJobs"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "StepFunctionsReadWrite"
+        Effect = "Allow"
+        Action = [
+          "states:Describe*",
+          "states:List*",
+          "states:Start*",
+          "states:Stop*",
+          "states:Get*"
+        ]
+        Resource = "arn:aws:states:${local.region}:${local.account_id}:stateMachine:${var.domain}-*"
+      },
+      {
+        Sid    = "SecretsManagerReadDomain"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds"
+        ]
+        Resource = "arn:aws:secretsmanager:${local.region}:${local.account_id}:secret:${var.domain}/*"
+      },
+      {
+        Sid    = "KMSUseDomainKey"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey"
+        ]
+        Resource = aws_kms_key.domain.arn
+      },
+      # Explicitly DENY LF permission management (admin cannot change grants)
+      {
+        Sid    = "DenyLakeFormationPermissionManagement"
+        Effect = "Deny"
+        Action = [
+          "lakeformation:GrantPermissions",
+          "lakeformation:RevokePermissions",
+          "lakeformation:BatchGrantPermissions",
+          "lakeformation:BatchRevokePermissions"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+##############################################################################
+# DomainDataEngineerRole
+# Read/write S3 (own buckets), create/run Glue jobs, read catalog.
+# Cannot modify LF permissions.
+# Trust: SSO | Permission boundary: s3:* restricted to own domain buckets.
+##############################################################################
+
+resource "aws_iam_role" "domain_data_engineer" {
+  name                 = "DomainDataEngineerRole"
+  description          = "Data engineer role for ${var.domain} domain. Trust: SSO."
+  permissions_boundary = aws_iam_policy.domain_s3_boundary.arn
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSSOAssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${local.account_id}:saml-provider/AWSSSO"
+        }
+        Action = "sts:AssumeRoleWithSAML"
+        Condition = {
+          StringEquals = {
+            "SAML:aud" = "https://signin.aws.amazon.com/saml"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "domain_data_engineer_policy" {
+  name = "${var.domain}-DomainDataEngineerPolicy"
+  role = aws_iam_role.domain_data_engineer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3DomainBuckets"
+        Effect = "Allow"
+        Action = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}/*"
+        ]
+      },
+      {
+        Sid    = "GlueJobsAndCatalog"
+        Effect = "Allow"
+        Action = [
+          "glue:GetDatabase*",
+          "glue:GetTable*",
+          "glue:CreateTable",
+          "glue:UpdateTable",
+          "glue:GetJob*",
+          "glue:CreateJob",
+          "glue:UpdateJob",
+          "glue:StartJobRun",
+          "glue:BatchStopJobRun",
+          "glue:GetJobRun*",
+          "glue:ListJobs",
+          "glue:GetDataQualityRuleset*",
+          "glue:CreateDataQualityRuleset",
+          "glue:StartDataQualityRulesetEvaluationRun"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "StepFunctionsRead"
+        Effect = "Allow"
+        Action = [
+          "states:DescribeStateMachine",
+          "states:DescribeExecution",
+          "states:ListExecutions",
+          "states:GetExecutionHistory",
+          "states:StartExecution"
+        ]
+        Resource = "arn:aws:states:${local.region}:${local.account_id}:stateMachine:${var.domain}-*"
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:GetLogEvents",
+          "logs:DescribeLogGroups"
+        ]
+        Resource = "arn:aws:logs:${local.region}:${local.account_id}:log-group:/data-meshy/${var.domain}/*"
+      },
+      {
+        Sid    = "KMSUseDomainKey"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey"
+        ]
+        Resource = aws_kms_key.domain.arn
+      }
+    ]
+  })
+}
+
+##############################################################################
+# DomainConsumerRole
+# Read-only on subscribed tables via LF grants. Athena query access.
+# Trust: SSO.
+##############################################################################
+
+resource "aws_iam_role" "domain_consumer" {
+  name        = "DomainConsumerRole"
+  description = "Read-only consumer role for ${var.domain} domain. Trust: SSO."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSSOAssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${local.account_id}:saml-provider/AWSSSO"
+        }
+        Action = "sts:AssumeRoleWithSAML"
+        Condition = {
+          StringEquals = {
+            "SAML:aud" = "https://signin.aws.amazon.com/saml"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "domain_consumer_policy" {
+  name = "${var.domain}-DomainConsumerPolicy"
+  role = aws_iam_role.domain_consumer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AthenaQueryAccess"
+        Effect = "Allow"
+        Action = [
+          "athena:StartQueryExecution",
+          "athena:GetQueryExecution",
+          "athena:GetQueryResults",
+          "athena:StopQueryExecution",
+          "athena:ListWorkGroups",
+          "athena:GetWorkGroup",
+          "athena:ListQueryExecutions",
+          "athena:BatchGetQueryExecution"
+        ]
+        Resource = "arn:aws:athena:${local.region}:${local.account_id}:workgroup/*"
+      },
+      {
+        Sid    = "AthenaResultsBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:GetBucketLocation",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::aws-athena-query-results-${local.account_id}-${local.region}",
+          "arn:aws:s3:::aws-athena-query-results-${local.account_id}-${local.region}/*"
+        ]
+      },
+      {
+        Sid    = "GlueCatalogRead"
+        Effect = "Allow"
+        Action = [
+          "glue:GetDatabase*",
+          "glue:GetTable*",
+          "glue:GetPartition*",
+          "glue:SearchTables"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "KMSDecryptForConsumer"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey"
+        ]
+        Resource = aws_kms_key.domain.arn
+      }
+    ]
+  })
+}
+
+##############################################################################
+# GlueJobExecutionRole
+# Trust: glue.amazonaws.com service only.
+# Permission boundary: S3 restricted to own domain buckets.
+# Grants: S3 R/W for all 3 layers, Glue catalog, Secrets Manager (domain-scoped),
+#         KMS decrypt/generate on domain key.
+##############################################################################
+
+resource "aws_iam_role" "glue_job_execution" {
+  name                 = "GlueJobExecutionRole"
+  description          = "Service role for Glue ETL jobs in ${var.domain} domain."
+  permissions_boundary = aws_iam_policy.domain_s3_boundary.arn
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "GlueServiceAssume"
+        Effect = "Allow"
+        Principal = {
+          Service = "glue.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "glue_job_execution_policy" {
+  name = "${var.domain}-GlueJobExecutionPolicy"
+  role = aws_iam_role.glue_job_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3DomainBuckets"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:AbortMultipartUpload",
+          "s3:ListMultipartUploadParts"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}/*",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}/*"
+        ]
+      },
+      {
+        Sid    = "GlueCatalogAccess"
+        Effect = "Allow"
+        Action = [
+          "glue:GetDatabase*",
+          "glue:GetTable*",
+          "glue:CreateTable",
+          "glue:UpdateTable",
+          "glue:GetPartition*",
+          "glue:BatchCreatePartition",
+          "glue:BatchDeletePartition",
+          "glue:UpdatePartition",
+          "glue:GetUserDefinedFunction*",
+          "glue:GetDataQualityRuleset*",
+          "glue:StartDataQualityRulesetEvaluationRun",
+          "glue:GetDataQualityRulesetEvaluationRun",
+          "glue:ListDataQualityRulesets"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "SecretsManagerDomainScoped"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = "arn:aws:secretsmanager:${local.region}:${local.account_id}:secret:${var.domain}/*"
+      },
+      {
+        Sid    = "KMSDomainKey"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey"
+        ]
+        Resource = aws_kms_key.domain.arn
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/glue/*"
+      },
+      {
+        Sid    = "LakeFormationGetDataAccess"
+        Effect = "Allow"
+        Action = "lakeformation:GetDataAccess"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+##############################################################################
+# MeshEventRole
+# Trust: lambda.amazonaws.com and states.amazonaws.com.
+# Grants: events:PutEvents on central event bus ONLY.
+# Condition: source CANNOT be datameshy.central (reserved for central SFN).
+##############################################################################
+
+resource "aws_iam_role" "mesh_event" {
+  name        = "MeshEventRole"
+  description = "PutEvents on central EventBridge bus for ${var.domain} domain. Trust: Lambda + Step Functions."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "LambdaAssume"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+      {
+        Sid    = "StepFunctionsAssume"
+        Effect = "Allow"
+        Principal = {
+          Service = "states.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "mesh_event_policy" {
+  name = "${var.domain}-MeshEventPolicy"
+  role = aws_iam_role.mesh_event.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # Allow PutEvents only on the central event bus
+      {
+        Sid    = "PutEventsToCentralBus"
+        Effect = "Allow"
+        Action = "events:PutEvents"
+        Resource = var.central_event_bus_arn
+      },
+      # Deny PutEvents with source = datameshy.central (reserved for central SFN)
+      {
+        Sid    = "DenyReservedCentralSource"
+        Effect = "Deny"
+        Action = "events:PutEvents"
+        Resource = var.central_event_bus_arn
+        Condition = {
+          StringEquals = {
+            "events:source" = "datameshy.central"
+          }
+        }
+      },
+      # Allow PutEvents on domain bus as well (for local events)
+      {
+        Sid    = "PutEventsToDomainBus"
+        Effect = "Allow"
+        Action = "events:PutEvents"
+        Resource = "arn:aws:events:${local.region}:${local.account_id}:event-bus/mesh-domain-bus"
+      },
+      # CloudWatch Logs for Lambda execution
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/*"
+      },
+      # Step Functions — allow Glue job start (needed for medallion pipeline SM)
+      {
+        Sid    = "GlueStartJobRun"
+        Effect = "Allow"
+        Action = [
+          "glue:StartJobRun",
+          "glue:GetJobRun",
+          "glue:BatchStopJobRun"
+        ]
+        Resource = "arn:aws:glue:${local.region}:${local.account_id}:job/*"
+      },
+      # CloudWatch Logs for Step Functions execution logs
+      {
+        Sid    = "SFNCloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogDelivery",
+          "logs:GetLogDelivery",
+          "logs:UpdateLogDelivery",
+          "logs:DeleteLogDelivery",
+          "logs:ListLogDeliveries",
+          "logs:PutResourcePolicy",
+          "logs:DescribeResourcePolicies",
+          "logs:DescribeLogGroups"
+        ]
+        Resource = "*"
+      },
+      # X-Ray tracing
+      {
+        Sid    = "XRayAccess"
+        Effect = "Allow"
+        Action = [
+          "xray:PutTraceSegments",
+          "xray:PutTelemetryRecords",
+          "xray:GetSamplingRules",
+          "xray:GetSamplingTargets"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/infra/modules/domain-account/lakeformation.tf
+++ b/infra/modules/domain-account/lakeformation.tf
@@ -1,0 +1,151 @@
+##############################################################################
+# domain-account/lakeformation.tf
+#
+# Lake Formation configuration:
+#   - LF admin settings for the domain account
+#   - LF-Tag: domain={domain_name}
+#   - LF-Tag binding to all gold catalog databases/tables
+#   - Database-level LF grants to GlueJobExecutionRole
+##############################################################################
+
+##############################################################################
+# Lake Formation Settings — mark GlueJobExecutionRole as a data lake admin
+# so it can register locations and create tables without IAMAllowedPrincipals.
+##############################################################################
+
+resource "aws_lakeformation_data_lake_settings" "domain" {
+  admins = [
+    aws_iam_role.glue_job_execution.arn,
+    aws_iam_role.domain_admin.arn
+  ]
+}
+
+##############################################################################
+# LF-Tags
+##############################################################################
+
+resource "aws_lakeformation_lf_tag" "domain_tag" {
+  key    = "domain"
+  values = [var.domain]
+
+  depends_on = [aws_lakeformation_data_lake_settings.domain]
+}
+
+resource "aws_lakeformation_lf_tag" "classification_tag" {
+  key    = "classification"
+  values = ["public", "internal", "confidential", "restricted"]
+
+  depends_on = [aws_lakeformation_data_lake_settings.domain]
+}
+
+resource "aws_lakeformation_lf_tag" "pii_tag" {
+  key    = "pii"
+  values = ["true", "false"]
+
+  depends_on = [aws_lakeformation_data_lake_settings.domain]
+}
+
+##############################################################################
+# Apply domain LF-Tag to the gold Glue catalog database.
+# (Individual tables get classification + pii tags in the data-product module)
+##############################################################################
+
+resource "aws_lakeformation_resource_lf_tags" "gold_db" {
+  database {
+    name = aws_glue_catalog_database.gold.name
+  }
+
+  lf_tag {
+    key   = "domain"
+    value = var.domain
+  }
+
+  depends_on = [
+    aws_lakeformation_lf_tag.domain_tag,
+    aws_glue_catalog_database.gold
+  ]
+}
+
+##############################################################################
+# LF Grants — GlueJobExecutionRole gets CREATE_TABLE + data access on all
+# three databases so it can write Iceberg tables during pipeline execution.
+##############################################################################
+
+resource "aws_lakeformation_permissions" "glue_raw_db" {
+  principal   = aws_iam_role.glue_job_execution.arn
+  permissions = ["CREATE_TABLE", "DESCRIBE"]
+
+  database {
+    name = aws_glue_catalog_database.raw.name
+  }
+
+  depends_on = [
+    aws_lakeformation_data_lake_settings.domain,
+    aws_lakeformation_resource.raw
+  ]
+}
+
+resource "aws_lakeformation_permissions" "glue_silver_db" {
+  principal   = aws_iam_role.glue_job_execution.arn
+  permissions = ["CREATE_TABLE", "DESCRIBE"]
+
+  database {
+    name = aws_glue_catalog_database.silver.name
+  }
+
+  depends_on = [
+    aws_lakeformation_data_lake_settings.domain,
+    aws_lakeformation_resource.silver
+  ]
+}
+
+resource "aws_lakeformation_permissions" "glue_gold_db" {
+  principal   = aws_iam_role.glue_job_execution.arn
+  permissions = ["CREATE_TABLE", "DESCRIBE", "ALTER", "DROP"]
+
+  database {
+    name = aws_glue_catalog_database.gold.name
+  }
+
+  depends_on = [
+    aws_lakeformation_data_lake_settings.domain,
+    aws_lakeformation_resource.gold
+  ]
+}
+
+##############################################################################
+# DomainDataEngineerRole — read access to all 3 databases for catalog browsing
+##############################################################################
+
+resource "aws_lakeformation_permissions" "engineer_raw_db" {
+  principal   = aws_iam_role.domain_data_engineer.arn
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = aws_glue_catalog_database.raw.name
+  }
+
+  depends_on = [aws_lakeformation_data_lake_settings.domain]
+}
+
+resource "aws_lakeformation_permissions" "engineer_silver_db" {
+  principal   = aws_iam_role.domain_data_engineer.arn
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = aws_glue_catalog_database.silver.name
+  }
+
+  depends_on = [aws_lakeformation_data_lake_settings.domain]
+}
+
+resource "aws_lakeformation_permissions" "engineer_gold_db" {
+  principal   = aws_iam_role.domain_data_engineer.arn
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = aws_glue_catalog_database.gold.name
+  }
+
+  depends_on = [aws_lakeformation_data_lake_settings.domain]
+}

--- a/infra/modules/domain-account/main.tf
+++ b/infra/modules/domain-account/main.tf
@@ -1,0 +1,188 @@
+##############################################################################
+# domain-account/main.tf
+#
+# Central orchestration file for the domain-account module.
+# Creates: KMS key, Glue catalog databases, Lake Formation registrations.
+# S3 buckets -> s3.tf | IAM roles -> iam.tf
+# LF Tag bindings -> lakeformation.tf | EventBridge -> eventbridge.tf
+##############################################################################
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30.0"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
+
+  # Mandatory tags applied to every resource in this module.
+  mandatory_tags = {
+    Project     = "data-meshy"
+    ManagedBy   = "terraform"
+    Environment = var.environment
+    Domain      = var.domain
+  }
+
+  tags = merge(local.mandatory_tags, var.tags)
+}
+
+##############################################################################
+# KMS — Domain Customer-Managed Key
+# Key policy grants: GlueJobExecutionRole (encrypt/decrypt),
+#   lakeformation service (decrypt for cross-account consumers),
+#   DomainAdminRole (admin), MeshAdminRole in central account (break-glass).
+# Consumers NEVER get direct KMS decrypt — only through Lake Formation.
+##############################################################################
+
+resource "aws_kms_key" "domain" {
+  description             = "Domain CMK for ${var.domain} — data-meshy"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # Root account admin — required so the key is not orphaned
+      {
+        Sid    = "RootAccountAdmin"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      # GlueJobExecutionRole — encrypt and decrypt for ETL operations
+      {
+        Sid    = "GlueJobEncryptDecrypt"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:role/GlueJobExecutionRole"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+      },
+      # Lake Formation service principal — decrypt on behalf of cross-account consumers
+      {
+        Sid    = "LakeFormationDecrypt"
+        Effect = "Allow"
+        Principal = {
+          Service = "lakeformation.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+      },
+      # DomainAdminRole — key administration within domain
+      {
+        Sid    = "DomainAdminKeyAdmin"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:role/DomainAdminRole"
+        }
+        Action = [
+          "kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Update*",
+          "kms:Revoke*",
+          "kms:Disable*",
+          "kms:Get*",
+          "kms:Delete*",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion"
+        ]
+        Resource = "*"
+      },
+      # MeshAdminRole in central account — break-glass only
+      {
+        Sid    = "CentralMeshAdminBreakGlass"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${var.central_account_id}:role/MeshAdminRole"
+        }
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = merge(local.tags, { Name = "mesh-${var.domain}" })
+}
+
+resource "aws_kms_alias" "domain" {
+  name          = "alias/mesh-${var.domain}"
+  target_key_id = aws_kms_key.domain.key_id
+}
+
+##############################################################################
+# Glue Catalog Databases — raw, silver, gold
+##############################################################################
+
+resource "aws_glue_catalog_database" "raw" {
+  name        = "${var.domain}_raw"
+  description = "Raw (Bronze) layer for ${var.domain} domain — data-meshy"
+
+  tags = local.tags
+}
+
+resource "aws_glue_catalog_database" "silver" {
+  name        = "${var.domain}_silver"
+  description = "Silver (Validated) layer for ${var.domain} domain — data-meshy"
+
+  tags = local.tags
+}
+
+resource "aws_glue_catalog_database" "gold" {
+  name        = "${var.domain}_gold"
+  description = "Gold (Data Product) layer for ${var.domain} domain — data-meshy"
+
+  tags = local.tags
+}
+
+##############################################################################
+# Lake Formation — Register S3 locations as data lake locations
+# The GlueJobExecutionRole is granted USE_LOCATION on each registered path.
+##############################################################################
+
+resource "aws_lakeformation_resource" "raw" {
+  arn      = "arn:aws:s3:::${var.domain}-raw-${local.account_id}"
+  role_arn = aws_iam_role.glue_job_execution.arn
+
+  depends_on = [aws_s3_bucket.raw]
+}
+
+resource "aws_lakeformation_resource" "silver" {
+  arn      = "arn:aws:s3:::${var.domain}-silver-${local.account_id}"
+  role_arn = aws_iam_role.glue_job_execution.arn
+
+  depends_on = [aws_s3_bucket.silver]
+}
+
+resource "aws_lakeformation_resource" "gold" {
+  arn      = "arn:aws:s3:::${var.domain}-gold-${local.account_id}"
+  role_arn = aws_iam_role.glue_job_execution.arn
+
+  depends_on = [aws_s3_bucket.gold]
+}

--- a/infra/modules/domain-account/outputs.tf
+++ b/infra/modules/domain-account/outputs.tf
@@ -1,0 +1,78 @@
+##############################################################################
+# domain-account/outputs.tf
+#
+# Output names are defined by the shared contract in plan/phases/phase-1/README.md.
+# These names are consumed by Stream 3 (pipeline-events) and Stream 4 (cli-ci).
+# DO NOT rename these outputs without updating the README contract.
+##############################################################################
+
+# S3 bucket names — consumed by Glue job parameters and Step Functions input
+output "raw_bucket_name" {
+  description = "S3 bucket name for the raw (Bronze) layer."
+  value       = aws_s3_bucket.raw.bucket
+}
+
+output "silver_bucket_name" {
+  description = "S3 bucket name for the silver (Validated) layer."
+  value       = aws_s3_bucket.silver.bucket
+}
+
+output "gold_bucket_name" {
+  description = "S3 bucket name for the gold (Data Product) layer."
+  value       = aws_s3_bucket.gold.bucket
+}
+
+# Glue catalog database names — consumed by Glue jobs, Step Functions input
+output "glue_catalog_db_raw" {
+  description = "Glue Data Catalog database name for the raw layer."
+  value       = aws_glue_catalog_database.raw.name
+}
+
+output "glue_catalog_db_silver" {
+  description = "Glue Data Catalog database name for the silver layer."
+  value       = aws_glue_catalog_database.silver.name
+}
+
+output "glue_catalog_db_gold" {
+  description = "Glue Data Catalog database name for the gold layer."
+  value       = aws_glue_catalog_database.gold.name
+}
+
+# IAM role ARNs — consumed by Step Functions task role + event publishers
+output "glue_job_execution_role_arn" {
+  description = "ARN of GlueJobExecutionRole — passed as execution role for Glue job definitions."
+  value       = aws_iam_role.glue_job_execution.arn
+}
+
+output "mesh_event_role_arn" {
+  description = "ARN of MeshEventRole — used by Lambda/Step Functions to PutEvents on the central bus."
+  value       = aws_iam_role.mesh_event.arn
+}
+
+# EventBridge
+output "domain_event_bus_arn" {
+  description = "ARN of the domain EventBridge bus (mesh-domain-bus)."
+  value       = aws_cloudwatch_event_bus.domain.arn
+}
+
+# KMS
+output "domain_kms_key_arn" {
+  description = "ARN of the domain KMS CMK (alias/mesh-{domain}). Used for S3 encryption context."
+  value       = aws_kms_key.domain.arn
+}
+
+# Additional convenience outputs (not in shared contract but useful for environment wiring)
+output "domain_kms_key_id" {
+  description = "Key ID of the domain KMS CMK."
+  value       = aws_kms_key.domain.key_id
+}
+
+output "domain_admin_role_arn" {
+  description = "ARN of DomainAdminRole."
+  value       = aws_iam_role.domain_admin.arn
+}
+
+output "domain_consumer_role_arn" {
+  description = "ARN of DomainConsumerRole."
+  value       = aws_iam_role.domain_consumer.arn
+}

--- a/infra/modules/domain-account/s3.tf
+++ b/infra/modules/domain-account/s3.tf
@@ -1,0 +1,310 @@
+##############################################################################
+# domain-account/s3.tf
+#
+# Three S3 buckets per domain: raw (Bronze), silver (Validated), gold (Product).
+#
+# Security model:
+#   - All buckets: SSE-KMS with domain CMK, bucket_key_enabled=true,
+#     versioning enabled, public access block, HTTPS-only deny, OrgID deny.
+#   - Raw + Silver: deny ALL cross-account access.
+#   - Gold: deny s3:GetObject to ALL principals EXCEPT GlueJobExecutionRole
+#     and lakeformation service-linked role (LF bypass prevention).
+#   - Raw: lifecycle — Glacier after 90 days, expire after 365 days.
+##############################################################################
+
+##############################################################################
+# RAW BUCKET
+##############################################################################
+
+resource "aws_s3_bucket" "raw" {
+  bucket = "${var.domain}-raw-${local.account_id}"
+  tags   = merge(local.tags, { Layer = "raw" })
+}
+
+resource "aws_s3_bucket_versioning" "raw" {
+  bucket = aws_s3_bucket.raw.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "raw" {
+  bucket = aws_s3_bucket.raw.id
+  rule {
+    bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.domain.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "raw" {
+  bucket                  = aws_s3_bucket.raw.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "raw" {
+  bucket = aws_s3_bucket.raw.id
+
+  rule {
+    id     = "raw-glacier-expire"
+    status = "Enabled"
+
+    filter {}
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "raw" {
+  bucket = aws_s3_bucket.raw.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # HTTPS-only
+      {
+        Sid       = "DenyNonTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}/*"
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      },
+      # Deny requests from outside the Organization
+      {
+        Sid       = "DenyNonOrgAccess"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}/*"
+        ]
+        Condition = {
+          StringNotEquals = { "aws:PrincipalOrgID" = var.aws_org_id }
+        }
+      },
+      # Deny ALL cross-account access (raw is internal to domain only)
+      {
+        Sid       = "DenyAllCrossAccountAccess"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-raw-${local.account_id}/*"
+        ]
+        Condition = {
+          StringNotEquals = { "aws:PrincipalAccount" = local.account_id }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.raw]
+}
+
+##############################################################################
+# SILVER BUCKET
+##############################################################################
+
+resource "aws_s3_bucket" "silver" {
+  bucket = "${var.domain}-silver-${local.account_id}"
+  tags   = merge(local.tags, { Layer = "silver" })
+}
+
+resource "aws_s3_bucket_versioning" "silver" {
+  bucket = aws_s3_bucket.silver.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "silver" {
+  bucket = aws_s3_bucket.silver.id
+  rule {
+    bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.domain.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "silver" {
+  bucket                  = aws_s3_bucket.silver.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "silver" {
+  bucket = aws_s3_bucket.silver.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # HTTPS-only
+      {
+        Sid       = "DenyNonTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}/*"
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      },
+      # Deny requests from outside the Organization
+      {
+        Sid       = "DenyNonOrgAccess"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}/*"
+        ]
+        Condition = {
+          StringNotEquals = { "aws:PrincipalOrgID" = var.aws_org_id }
+        }
+      },
+      # Deny ALL cross-account access (silver is internal to domain only)
+      {
+        Sid       = "DenyAllCrossAccountAccess"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-silver-${local.account_id}/*"
+        ]
+        Condition = {
+          StringNotEquals = { "aws:PrincipalAccount" = local.account_id }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.silver]
+}
+
+##############################################################################
+# GOLD BUCKET — stricter policy to prevent Lake Formation bypass
+##############################################################################
+
+resource "aws_s3_bucket" "gold" {
+  bucket = "${var.domain}-gold-${local.account_id}"
+  tags   = merge(local.tags, { Layer = "gold" })
+}
+
+resource "aws_s3_bucket_versioning" "gold" {
+  bucket = aws_s3_bucket.gold.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "gold" {
+  bucket = aws_s3_bucket.gold.id
+  rule {
+    bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.domain.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "gold" {
+  bucket                  = aws_s3_bucket.gold.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "gold" {
+  bucket = aws_s3_bucket.gold.id
+
+  # CRITICAL: This policy prevents Lake Formation bypass.
+  # All GetObject requests are denied EXCEPT from:
+  #   1. GlueJobExecutionRole (ETL jobs write/read gold data)
+  #   2. Lake Formation service-linked role (serves cross-account consumers)
+  # This means no IAM role — even with s3:GetObject on the bucket — can
+  # bypass Lake Formation and read gold data directly.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # LF-bypass prevention: deny GetObject to all except approved principals
+      {
+        Sid       = "DenyDirectGetObjectExceptLFAndGlue"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "arn:aws:s3:::${var.domain}-gold-${local.account_id}/*"
+        Condition = {
+          StringNotLike = {
+            "aws:PrincipalArn" = [
+              "arn:aws:iam::${local.account_id}:role/GlueJobExecutionRole",
+              "arn:aws:iam::${local.account_id}:role/aws-service-role/lakeformation.amazonaws.com/*"
+            ]
+          }
+        }
+      },
+      # HTTPS-only
+      {
+        Sid       = "DenyNonTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}/*"
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      },
+      # Deny requests from outside the Organization
+      {
+        Sid       = "DenyNonOrgAccess"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}",
+          "arn:aws:s3:::${var.domain}-gold-${local.account_id}/*"
+        ]
+        Condition = {
+          StringNotEquals = { "aws:PrincipalOrgID" = var.aws_org_id }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.gold]
+}

--- a/infra/modules/domain-account/variables.tf
+++ b/infra/modules/domain-account/variables.tf
@@ -1,0 +1,53 @@
+variable "domain" {
+  description = "Domain name (e.g. sales, marketing). Used in all resource naming."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.domain))
+    error_message = "Domain must be lowercase alphanumeric with hyphens, starting with a letter."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. dev, staging, prod)."
+  type        = string
+  default     = "dev"
+}
+
+variable "aws_region" {
+  description = "AWS region for domain resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_org_id" {
+  description = "AWS Organization ID (o-xxxxxxxxxx). Used in bucket policy OrgID condition."
+  type        = string
+}
+
+variable "central_account_id" {
+  description = "Account ID of the central governance account. Used in KMS key policy for MeshAdminRole break-glass access."
+  type        = string
+}
+
+variable "central_event_bus_arn" {
+  description = "ARN of the central EventBridge bus (from Stream 1 governance module). Events with source=datameshy are forwarded here."
+  type        = string
+}
+
+variable "mesh_catalog_writer_role_arn" {
+  description = "ARN of MeshCatalogWriterRole in the central account (from Stream 1). Referenced in domain trust policy."
+  type        = string
+}
+
+variable "sso_identity_store_id" {
+  description = "IAM Identity Center Identity Store ID, used for SSO trust policies."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Additional tags to merge with the mandatory tag set."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -1,0 +1,233 @@
+##############################################################################
+# monitoring/main.tf
+#
+# CloudWatch alarms, log groups, and AWS Budgets for a domain account.
+# Phase 1 MVP — basic but pager-worthy alarms:
+#   - Lambda error rate > 1 in 5 min -> SNS alert
+#   - SQS DLQ message count > 0 -> SNS alert
+#   - Step Functions execution failures > 0 in 5 min -> SNS alert
+#   - Glue job failure -> CloudWatch metric alarm -> SNS alert
+#   - AWS Budget alerts at $20/$50/$100 monthly thresholds
+##############################################################################
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30.0"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  mandatory_tags = {
+    Project     = "data-meshy"
+    ManagedBy   = "terraform"
+    Environment = var.environment
+    Domain      = var.domain
+  }
+
+  tags = merge(local.mandatory_tags, var.tags)
+}
+
+##############################################################################
+# CloudWatch Log Groups — 30-day retention for all domain Lambda functions
+##############################################################################
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  count = length(var.lambda_function_names)
+
+  name              = "/aws/lambda/${var.lambda_function_names[count.index]}"
+  retention_in_days = 30
+
+  tags = merge(local.tags, {
+    Name = "${var.domain}-lambda-${var.lambda_function_names[count.index]}-logs"
+  })
+}
+
+##############################################################################
+# CloudWatch Log Group — Step Functions state machine execution logs
+##############################################################################
+
+resource "aws_cloudwatch_log_group" "step_functions" {
+  count = var.state_machine_arn != "" ? 1 : 0
+
+  name              = "/data-meshy/${var.domain}/pipeline"
+  retention_in_days = 30
+
+  tags = merge(local.tags, {
+    Name = "${var.domain}-step-functions-logs"
+  })
+}
+
+##############################################################################
+# Alarms: Lambda Errors
+# Triggers when any Lambda function has > 1 error in a 5-minute window.
+##############################################################################
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  count = length(var.lambda_function_names)
+
+  alarm_name          = "${var.domain}-lambda-error-${var.lambda_function_names[count.index]}"
+  alarm_description   = "Lambda function ${var.lambda_function_names[count.index]} error count > 1 in 5 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = var.lambda_function_names[count.index]
+  }
+
+  alarm_actions = [var.alarm_notification_arn]
+  ok_actions    = [var.alarm_notification_arn]
+
+  tags = merge(local.tags, {
+    Name = "${var.domain}-lambda-error-${var.lambda_function_names[count.index]}"
+  })
+}
+
+##############################################################################
+# Alarms: SQS DLQ Message Count
+# Triggers when any DLQ has > 0 messages (any message in a DLQ is an incident).
+##############################################################################
+
+resource "aws_cloudwatch_metric_alarm" "dlq_depth" {
+  for_each = var.dlq_queue_arns
+
+  alarm_name          = "${var.domain}-dlq-depth-${replace(each.key, "_", "-")}"
+  alarm_description   = "DLQ ${each.key} has messages. Any message in a DLQ is an incident."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    QueueName = each.key
+  }
+
+  alarm_actions = [var.alarm_notification_arn]
+  ok_actions    = [var.alarm_notification_arn]
+
+  tags = merge(local.tags, {
+    Name = "${var.domain}-dlq-${each.key}"
+  })
+}
+
+##############################################################################
+# Alarm: Step Functions Execution Failures
+# Triggers when the state machine has > 0 failed executions in 5 minutes.
+##############################################################################
+
+resource "aws_cloudwatch_metric_alarm" "sfn_failures" {
+  count = var.state_machine_arn != "" ? 1 : 0
+
+  alarm_name          = "${var.domain}-sfn-pipeline-failures"
+  alarm_description   = "Step Functions pipeline execution failures > 0 in 5 minutes for ${var.domain}."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ExecutionsFailed"
+  namespace           = "AWS/States"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    StateMachineArn = var.state_machine_arn
+  }
+
+  alarm_actions = [var.alarm_notification_arn]
+  ok_actions    = [var.alarm_notification_arn]
+
+  tags = merge(local.tags, {
+    Name = "${var.domain}-sfn-pipeline-failures"
+  })
+}
+
+##############################################################################
+# Alarms: Glue Job Failures
+# Triggers when any Glue job has a failure (metric: glue.driver.aggregate.numFailedTasks).
+##############################################################################
+
+resource "aws_cloudwatch_metric_alarm" "glue_failures" {
+  count = length(var.glue_job_names)
+
+  alarm_name          = "${var.domain}-glue-failure-${var.glue_job_names[count.index]}"
+  alarm_description   = "Glue job ${var.glue_job_names[count.index]} failure detected for ${var.domain}."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "glue.driver.aggregate.numFailedTasks"
+  namespace           = "Glue"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    JobName = var.glue_job_names[count.index]
+    JobRunId = "ALL"
+    Type     = "gauge"
+  }
+
+  alarm_actions = [var.alarm_notification_arn]
+  ok_actions    = [var.alarm_notification_arn]
+
+  tags = merge(local.tags, {
+    Name = "${var.domain}-glue-${var.glue_job_names[count.index]}"
+  })
+}
+
+##############################################################################
+# AWS Budgets — alert at configured thresholds ($20, $50, $100 default)
+##############################################################################
+
+resource "aws_budgets_budget" "domain" {
+  count = length(var.budget_thresholds) > 0 ? 1 : 0
+
+  name         = "${var.domain}-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = tostring(max(var.budget_thresholds...))
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  dynamic "cost_filter" {
+    for_each = [
+      {
+        name = "TagKeyValue"
+        values = ["user:Domain$${var.domain}"]
+      }
+    ]
+    content {
+      name   = cost_filter.value.name
+      values = cost_filter.value.values
+    }
+  }
+
+  dynamic "notification" {
+    for_each = var.budget_thresholds
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = notification.value
+      threshold_type             = "ABSOLUTE_VALUE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = length(var.budget_email_recipients) > 0 ? var.budget_email_recipients : null
+      subscriber_sns_topic_arns  = length(var.budget_email_recipients) == 0 ? [var.alarm_notification_arn] : []
+    }
+  }
+
+  tags = local.tags
+}

--- a/infra/modules/monitoring/variables.tf
+++ b/infra/modules/monitoring/variables.tf
@@ -1,0 +1,70 @@
+##############################################################################
+# monitoring/variables.tf
+#
+# Variables for the monitoring module.
+# CloudWatch alarms, log groups, and AWS Budgets.
+##############################################################################
+
+variable "domain" {
+  description = "Domain name (e.g. sales). Used in alarm naming and log group paths."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)."
+  type        = string
+  default     = "dev"
+}
+
+variable "aws_region" {
+  description = "AWS region for monitoring resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "alarm_notification_arn" {
+  description = "SNS topic ARN for alarm notifications (from governance module quality_alert_sns_topic_arn or a dedicated ops topic)."
+  type        = string
+}
+
+variable "lambda_function_names" {
+  description = "List of Lambda function names in this domain to monitor for errors."
+  type        = list(string)
+  default     = []
+}
+
+variable "dlq_queue_arns" {
+  description = "Map of DLQ queue name -> ARN to monitor for message count > 0."
+  type        = map(string)
+  default     = {}
+}
+
+variable "state_machine_arn" {
+  description = "Step Functions state machine ARN to monitor for execution failures."
+  type        = string
+  default     = ""
+}
+
+variable "glue_job_names" {
+  description = "List of Glue job names to monitor for failures."
+  type        = list(string)
+  default     = []
+}
+
+variable "budget_thresholds" {
+  description = "List of monthly budget threshold amounts (USD) for AWS Budgets alerts."
+  type        = list(number)
+  default     = [20, 50, 100]
+}
+
+variable "budget_email_recipients" {
+  description = "List of email addresses for AWS Budgets alerts."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Additional tags to merge with the mandatory set."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- Domain account Terraform module: 3 S3 buckets (raw/silver/gold) with SSE-KMS, bucket_key_enabled, gold bucket deny policy, IAM roles with permission boundaries, Glue Catalog DBs, Lake Formation registration, EventBridge forwarding
- Data product module: Iceberg table, Glue Data Quality ruleset, Step Functions state machine, DynamoDB catalog entry, Secrets Manager for source credentials
- Monitoring module: CloudWatch alarms (Lambda errors, DLQ depth, SFN failures, Glue failures), AWS Budgets ($20/$50/$100)
- Domain-sales environment: complete instantiation for `sales` domain with `customer_orders` product

## Files changed (20 files, 2,919 insertions)
- `infra/modules/domain-account/` — S3, IAM, Lake Formation, EventBridge, outputs
- `infra/modules/data-product/` — Iceberg, quality, Step Functions, catalog, outputs
- `infra/modules/monitoring/` — CloudWatch alarms + budgets
- `infra/environments/domain-sales/` — full environment config with customer_orders schema

## Test plan
- [ ] `terraform validate` passes for all modules
- [ ] S3 buckets have SSE-KMS with bucket_key_enabled=true
- [ ] Gold bucket denies s3:GetObject to non-GlueJobExecutionRole principals
- [ ] GlueJobExecutionRole has permission boundary restricting to own domain buckets
- [ ] Step Functions state machine references ASL template correctly
- [ ] Monitoring alarms cover all DLQs and Lambda/Step Functions/Glue failures
- [ ] Domain-sales environment variables match customer_orders spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)