### PR TITLE
Phase 2 Stream 4: Marketing Domain Examples & Integration

### DIFF
--- a/examples/marketing-domain/README.md
+++ b/examples/marketing-domain/README.md
@@ -1,0 +1,226 @@
+# Marketing Domain — Subscribing to sales/customer_orders
+
+This walkthrough shows the marketing domain consuming the `sales/customer_orders` data
+product.  It covers two personas and two flows:
+
+| Persona | Tool | Flow |
+|---------|------|------|
+| Marketing analyst (technical) | `datameshy` CLI + boto3 | CLI subscription + Athena query |
+| Product owner / governance lead | AWS DataZone web UI | Portal-based subscription approval |
+
+**What you will end up with**: a resource link `marketing_catalog.sales_customer_orders`
+visible in the marketing account's Athena, containing only non-PII columns
+(`order_id`, `order_date`, `order_total`).  The PII column `customer_email` is
+blocked by Lake Formation column-level filtering and cannot be queried.
+
+---
+
+## Prerequisites
+
+- Phase 1 deployed (governance account + sales domain pipeline running).
+- Phase 2 Stream 1 deployed (`subscription-provisioner` Step Function, DynamoDB table, API routes).
+- Phase 2 Stream 2 deployed (subscription Lambda handlers).
+- `datameshy` CLI installed: `pip install data-meshy`
+- AWS credentials configured for both the **marketing account** and the **sales/producer account**.
+
+---
+
+## Flow A — CLI (technical persona)
+
+### Step 1: Request a subscription
+
+From the **marketing account**:
+
+```bash
+datameshy subscribe request \
+  --product sales/customer_orders \
+  --columns order_id,order_date,order_total \
+  --justification "Marketing attribution model requires order date and total; email excluded (PII)."
+```
+
+Expected output:
+
+```json
+{
+  "subscription_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "status": "PENDING",
+  "product_id": "sales/customer_orders",
+  "requested_columns": ["order_id", "order_date", "order_total"]
+}
+```
+
+The `SubscriptionRequested` event is published to the central EventBridge bus.
+The sales product owner is notified.
+
+### Step 2: Approve the subscription (producer side)
+
+The **sales account** approves the subscription.  Either the governance team runs
+this command from the producer account profile, or the product owner uses the
+DataZone UI (see Flow B below):
+
+```bash
+datameshy subscribe approve --subscription-id a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Behind the scenes the `subscription-provisioner` Step Function runs the saga:
+
+1. Lake Formation cross-account grant (non-PII columns only).
+2. KMS key grant so the marketing account can decrypt Iceberg data files.
+3. Resource link creation in the marketing Glue catalog: `marketing_catalog.sales_customer_orders`.
+
+On success a `SubscriptionApproved` event is published.  On failure, the
+compensator revokes any partial grants, sets `status = "FAILED"`, and publishes
+a `SubscriptionRevoked` event with `revoked_by = "system"` and a
+`compensation_reason` describing which step failed.
+
+### Step 3: Verify the subscription is ACTIVE
+
+```bash
+datameshy subscribe list --product sales/customer_orders --status ACTIVE
+```
+
+Expected output:
+
+```
+subscription_id                        product_id              status  columns
+a1b2c3d4-e5f6-7890-abcd-ef1234567890  sales/customer_orders   ACTIVE  order_id, order_date, order_total
+```
+
+### Step 4: Query via Athena
+
+Set required environment variables, then run the query script:
+
+```bash
+export AWS_PROFILE=marketing
+export ATHENA_OUTPUT_BUCKET=s3://marketing-athena-results-123456789012/
+python query_customer_orders.py
+```
+
+The script runs:
+
+```sql
+SELECT order_id, order_date, order_total
+FROM marketing_catalog.sales_customer_orders
+LIMIT 10
+```
+
+And prints a formatted table, for example:
+
+```
++-------------------+------------+-------------+
+| order_id          | order_date | order_total |
++-------------------+------------+-------------+
+| ORD-42-000001     | 2026-01-15 | 142.50      |
+| ORD-42-000002     | 2026-01-16 | 87.99       |
+| ...               | ...        | ...         |
++-------------------+------------+-------------+
+```
+
+### Column filtering — PII is not accessible
+
+The `customer_email` column is marked `pii: true` in the product spec and is
+excluded from the Lake Formation grant.  Querying it returns an access denied
+error at the Athena/LF layer:
+
+```sql
+-- This query will FAIL with Access Denied
+SELECT order_id, customer_email
+FROM marketing_catalog.sales_customer_orders
+LIMIT 1
+```
+
+The commented-out `BLOCKED_PII_QUERY` block in `query_customer_orders.py`
+demonstrates this behaviour.
+
+### Automated script
+
+`subscribe_to_customer_orders.sh` wraps all three CLI steps in a single script
+parameterised via environment variables.  See the file header for usage.
+
+---
+
+## Flow B — DataZone web UI (product owner / governance lead persona)
+
+This flow does not require CLI access.  The product owner approves or rejects
+subscription requests directly in the AWS DataZone portal.
+
+### 1. Consumer: Browse the catalog and request access
+
+1. Sign in to the AWS DataZone portal for the marketing domain project.
+2. Navigate to **Catalog** > **Search** and search for `customer_orders`.
+3. Select the `sales / customer_orders` asset.
+4. Click **Request subscription** and fill in:
+   - **Columns requested**: `order_id`, `order_date`, `order_total`
+   - **Justification**: explain why your team needs access.
+5. Submit the request.
+
+DataZone publishes a `SubscriptionRequested` event to the central EventBridge
+bus, which routes a notification to the sales domain team.
+
+### 2. Producer: Approve the request in DataZone
+
+1. The sales product owner receives an email notification (via SNS/SES) or sees
+   the pending request in the DataZone portal under **My subscriptions to review**.
+2. Select the pending request from marketing.
+3. Review the requested columns and justification.
+4. Click **Approve**.
+
+DataZone emits a `SubscriptionApproved` event.  The `subscription-provisioner`
+Step Function picks it up and runs the same saga as the CLI flow (LF grant →
+KMS grant → resource link).
+
+### 3. Consumer: Verify the subscription in DataZone
+
+1. Return to the DataZone portal (marketing project).
+2. Navigate to **My subscriptions**.
+3. The status should change from **Pending** to **Active** within a few minutes
+   (LF grant propagation typically takes 30–90 seconds).
+4. The subscribed table appears under **My data** as `sales_customer_orders`.
+5. Click **Query in Athena** to open the Athena console pre-loaded with the
+   resource link database.
+
+---
+
+## What to expect when a subscription fails
+
+If the saga fails mid-flight (e.g., the LF grant succeeds but the KMS grant
+fails), the compensator rolls back:
+
+1. The partial LF grant is revoked.
+2. A `SubscriptionRevoked` event is published with `revoked_by = "system"` and
+   a `compensation_reason` string such as `"KMS grant failed: AccessDenied"`.
+3. The subscription record in DynamoDB is updated to `status = "FAILED"` with
+   a `compensation_reason` field.
+
+You can inspect the failed subscription via the CLI:
+
+```bash
+datameshy subscribe list --product sales/customer_orders --status FAILED
+```
+
+Or via the DynamoDB console in the governance account:
+
+- Table: `mesh-subscriptions`
+- Partition key: `sales/customer_orders`
+- Sort key: `<marketing-account-id>`
+- Inspect `status`, `compensation_reason`, and `provisioning_steps`.
+
+To retry, revoke the failed subscription and request again:
+
+```bash
+datameshy subscribe revoke --subscription-id <id>
+datameshy subscribe request \
+  --product sales/customer_orders \
+  --columns order_id,order_date,order_total \
+  --justification "Retry after compensation."
+```
+
+---
+
+## File index
+
+| File | Purpose |
+|------|---------|
+| `subscribe_to_customer_orders.sh` | CLI subscription flow (all three steps in one script) |
+| `query_customer_orders.py` | Athena query via boto3, demonstrates PII column blocking |
+| `README.md` | This walkthrough |

--- a/examples/marketing-domain/query_customer_orders.py
+++ b/examples/marketing-domain/query_customer_orders.py
@@ -1,0 +1,154 @@
+"""Query the sales/customer_orders data product from the marketing domain account.
+
+This script demonstrates that a marketing analyst can query non-PII columns
+of the sales/customer_orders product via the resource link created by the
+subscription workflow.  The PII column (customer_email) is NOT accessible —
+Lake Formation column-level filtering enforces this at query time.
+
+Prerequisites:
+  - The subscription to sales/customer_orders must be ACTIVE (run subscribe_to_customer_orders.sh first).
+  - boto3 installed: pip install boto3
+  - AWS credentials configured for the MARKETING account.
+  - Environment variables (see below).
+
+Environment variables:
+  AWS_PROFILE          — AWS CLI profile for the marketing account (default: default).
+  ATHENA_WORKGROUP     — Athena workgroup name (default: primary).
+  ATHENA_OUTPUT_BUCKET — S3 bucket for Athena query results.
+                         Example: s3://marketing-athena-results-123456789012/
+  AWS_REGION           — AWS region (default: us-east-1).
+
+Usage:
+  AWS_PROFILE=marketing \\
+  ATHENA_OUTPUT_BUCKET=s3://marketing-athena-results-123456789012/ \\
+  python query_customer_orders.py
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import boto3
+
+
+# ---------------------------------------------------------------------------
+# Configuration from environment
+# ---------------------------------------------------------------------------
+
+AWS_PROFILE = os.environ.get("AWS_PROFILE", "default")
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+ATHENA_WORKGROUP = os.environ.get("ATHENA_WORKGROUP", "primary")
+ATHENA_OUTPUT_BUCKET = os.environ.get("ATHENA_OUTPUT_BUCKET", "")
+
+# The resource link is created in the marketing account's Glue catalog by the
+# subscription saga.  It mirrors the sales account's gold Iceberg table.
+RESOURCE_LINK_DATABASE = "marketing_catalog"
+RESOURCE_LINK_TABLE = "sales_customer_orders"
+
+# Columns available to marketing (non-PII, as defined in the approved subscription).
+ALLOWED_QUERY = (
+    f"SELECT order_id, order_date, order_total "
+    f"FROM {RESOURCE_LINK_DATABASE}.{RESOURCE_LINK_TABLE} "
+    f"LIMIT 10"
+)
+
+# This query will be rejected by Lake Formation with an Access Denied error
+# because customer_email is a PII column excluded from the subscription grant.
+# Uncomment and run to observe the expected error.
+#
+# BLOCKED_PII_QUERY = (
+#     f"SELECT order_id, customer_email "
+#     f"FROM {RESOURCE_LINK_DATABASE}.{RESOURCE_LINK_TABLE} "
+#     f"LIMIT 1"
+# )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _poll_query(client: "boto3.client", query_execution_id: str, poll_interval: float = 1.0) -> dict:
+    """Poll Athena until the query finishes and return the execution details."""
+    terminal_states = {"SUCCEEDED", "FAILED", "CANCELLED"}
+    while True:
+        response = client.get_query_execution(QueryExecutionId=query_execution_id)
+        state = response["QueryExecution"]["Status"]["State"]
+        if state in terminal_states:
+            return response["QueryExecution"]
+        time.sleep(poll_interval)
+
+
+def _fetch_results(client: "boto3.client", query_execution_id: str) -> list[list[str]]:
+    """Return all rows from an Athena query result (header row first)."""
+    rows: list[list[str]] = []
+    paginator = client.get_paginator("get_query_results")
+    for page in paginator.paginate(QueryExecutionId=query_execution_id):
+        for row in page["ResultSet"]["Rows"]:
+            rows.append([col.get("VarCharValue", "") for col in row["Data"]])
+    return rows
+
+
+def _print_table(rows: list[list[str]]) -> None:
+    """Print rows as a left-aligned text table."""
+    if not rows:
+        print("(no rows returned)")
+        return
+    col_widths = [max(len(r[i]) for r in rows) for i in range(len(rows[0]))]
+    separator = "+-" + "-+-".join("-" * w for w in col_widths) + "-+"
+    print(separator)
+    for idx, row in enumerate(rows):
+        line = "| " + " | ".join(cell.ljust(col_widths[i]) for i, cell in enumerate(row)) + " |"
+        print(line)
+        if idx == 0:
+            print(separator)
+    print(separator)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    if not ATHENA_OUTPUT_BUCKET:
+        raise SystemExit(
+            "Error: ATHENA_OUTPUT_BUCKET environment variable is required.\n"
+            "Example: export ATHENA_OUTPUT_BUCKET=s3://marketing-athena-results-123456789012/"
+        )
+
+    session = boto3.Session(profile_name=AWS_PROFILE, region_name=AWS_REGION)
+    athena = session.client("athena")
+
+    print(f"Running query against resource link: {RESOURCE_LINK_DATABASE}.{RESOURCE_LINK_TABLE}")
+    print(f"SQL: {ALLOWED_QUERY}")
+    print()
+
+    start = athena.start_query_execution(
+        QueryString=ALLOWED_QUERY,
+        QueryExecutionContext={"Database": RESOURCE_LINK_DATABASE},
+        ResultConfiguration={"OutputLocation": ATHENA_OUTPUT_BUCKET},
+        WorkGroup=ATHENA_WORKGROUP,
+    )
+    query_id = start["QueryExecutionId"]
+    print(f"Query execution ID: {query_id}")
+
+    execution = _poll_query(athena, query_id)
+    state = execution["Status"]["State"]
+
+    if state != "SUCCEEDED":
+        reason = execution["Status"].get("StateChangeReason", "unknown")
+        raise SystemExit(f"Query {state}: {reason}")
+
+    rows = _fetch_results(athena, query_id)
+    print(f"Query succeeded. Rows returned (including header): {len(rows)}")
+    print()
+    _print_table(rows)
+
+    print()
+    print("Note: querying customer_email would return an Access Denied error.")
+    print("      Lake Formation column-level filtering enforces PII restrictions.")
+    print("      Uncomment BLOCKED_PII_QUERY in this script to verify the behaviour.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/marketing-domain/subscribe_to_customer_orders.sh
+++ b/examples/marketing-domain/subscribe_to_customer_orders.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# subscribe_to_customer_orders.sh
+#
+# Marketing domain: request and activate a subscription to sales/customer_orders.
+#
+# Prerequisites:
+#   - datameshy CLI installed and on PATH (pip install data-meshy)
+#   - AWS credentials configured for the MARKETING account
+#   - AWS_PROFILE set to the marketing domain profile (or use the default profile)
+#
+# Environment variables:
+#   AWS_PROFILE         — AWS CLI profile for the marketing account (default: default)
+#   SUBSCRIPTION_ID     — Populated automatically after step 1; set manually to resume
+#   PRODUCER_AWS_PROFILE — AWS CLI profile for the sales/producer account (for step 2)
+#
+# Usage:
+#   # Full flow (marketing + producer profiles available on this machine)
+#   AWS_PROFILE=marketing PRODUCER_AWS_PROFILE=sales bash subscribe_to_customer_orders.sh
+#
+#   # Resume from approval step (subscription already requested)
+#   SUBSCRIPTION_ID=<uuid> AWS_PROFILE=marketing PRODUCER_AWS_PROFILE=sales bash subscribe_to_customer_orders.sh
+
+set -euo pipefail
+
+AWS_PROFILE="${AWS_PROFILE:-default}"
+PRODUCER_AWS_PROFILE="${PRODUCER_AWS_PROFILE:-default}"
+
+echo "=== Step 1: Request subscription to sales/customer_orders ==="
+echo "Account profile : ${AWS_PROFILE}"
+echo "Requesting columns: order_id, order_date, order_total (non-PII only)"
+echo ""
+
+# The CLI writes the subscription_id to stdout on success.
+# Capture it and export for use in subsequent steps.
+if [[ -z "${SUBSCRIPTION_ID:-}" ]]; then
+  SUBSCRIPTION_ID=$(
+    AWS_PROFILE="${AWS_PROFILE}" datameshy subscribe request \
+      --product sales/customer_orders \
+      --columns order_id,order_date,order_total \
+      --justification "Marketing attribution model requires order date and total; email excluded (PII)." \
+      --output json \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['subscription_id'])"
+  )
+  echo "Subscription requested. ID: ${SUBSCRIPTION_ID}"
+else
+  echo "Using existing SUBSCRIPTION_ID: ${SUBSCRIPTION_ID}"
+fi
+
+echo ""
+echo "=== Step 2: Approve the subscription (producer / sales account) ==="
+echo "Account profile : ${PRODUCER_AWS_PROFILE}"
+echo "Note: in production, the data product owner approves via the DataZone web UI"
+echo "      or the governance team runs this command from the producer account."
+echo ""
+
+AWS_PROFILE="${PRODUCER_AWS_PROFILE}" datameshy subscribe approve \
+  --subscription-id "${SUBSCRIPTION_ID}"
+
+echo "Subscription approved."
+
+echo ""
+echo "=== Step 3: Verify the subscription is ACTIVE (marketing account) ==="
+echo ""
+
+AWS_PROFILE="${AWS_PROFILE}" datameshy subscribe list \
+  --product sales/customer_orders \
+  --status ACTIVE
+
+echo ""
+echo "=== Done ==="
+echo "The resource link 'marketing_catalog.sales_customer_orders' is now available in Athena."
+echo "Run query_customer_orders.py to query the data."

--- a/schemas/events/SubscriptionRevoked.json
+++ b/schemas/events/SubscriptionRevoked.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/data-meshy/schemas/events/SubscriptionRevoked.json",
+  "title": "SubscriptionRevoked",
+  "description": "Event emitted when an active subscription is revoked, either manually by an IAM principal or automatically by the system (e.g., policy violation, compensation after a failed provisioning step).",
+  "type": "object",
+  "required": ["subscription_id", "product_id", "consumer_account_id", "revoked_by", "revoked_at"],
+  "properties": {
+    "subscription_id": {
+      "description": "Unique identifier of the subscription being revoked (UUID format).",
+      "type": "string",
+      "format": "uuid"
+    },
+    "product_id": {
+      "description": "Composite key identifying the data product: domain#product_name.",
+      "type": "string"
+    },
+    "consumer_account_id": {
+      "description": "AWS account ID of the consumer whose access is being revoked.",
+      "type": "string"
+    },
+    "revoked_by": {
+      "description": "IAM principal ARN that triggered the revocation, or 'system' for automatic compensation revokes.",
+      "type": "string"
+    },
+    "revoked_at": {
+      "description": "ISO 8601 timestamp when the revocation was processed.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "reason": {
+      "description": "Human-readable reason for revocation (e.g., 'Policy violation', 'Compensation: LF grant failed').",
+      "type": "string"
+    },
+    "compensation_reason": {
+      "description": "Machine-readable reason set by the saga compensator when auto-revoking after a failed provisioning step.",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Completed Phase 2 with runnable examples demonstrating the full subscription workflow:
- **marketing-domain/README.md** — step-by-step walkthrough (CLI and DataZone portal)
- **subscribe_to_customer_orders.sh** — shell script showing CLI subscription flow
- **query_customer_orders.py** — boto3 Athena query demonstrating PII column blocking
- **SubscriptionRevoked.json** — event schema for both manual and automated revocations

## Key Decisions
- Schema covers both manual revoke (product owner) and automatic compensation (saga rollback)
- Scripts assume real AWS accounts; integration testing requires deployed Phase 1 + Phase 2 infra
- Pagination support in query script follows boto3 idioms used throughout codebase
- README documents failure/compensation path for operator diagnostics

## Files Changed
- examples/marketing-domain/* (new directory)
- schemas/events/SubscriptionRevoked.json

## Tests
No unit tests (reference examples). Runnable against deployed AWS accounts.

## Dependencies
**Depends on**: Streams 1, 2, 3 (all infrastructure and CLI commands)
**Feeds**: Phase 2 verification

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)