### PR TITLE
Pre-Phase 3 Stream 1: domain init/upgrade CLI commands & tests

### DIFF
--- a/cli/datameshy/commands/domain.py
+++ b/cli/datameshy/commands/domain.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
+from jinja2 import BaseLoader, Environment
 from rich.console import Console
 from rich.table import Table
 
@@ -227,8 +228,8 @@ def domain_init(
         raise typer.BadParameter(f"account-id must be a 12-digit AWS account ID (got: {account_id}).")
     if "@" not in owner:
         raise typer.BadParameter(f"owner must be a valid email address (got: {owner}).")
-
-    from jinja2 import Environment, BaseLoader
+    if not re.match(r"^\d+\.\d+\.\d+$", platform_version):
+        raise typer.BadParameter(f"platform-version must be semver X.Y.Z (got: {platform_version}).")
 
     dest_root = (output_dir or Path.cwd()) / f"data-meshy-{name}"
 
@@ -242,6 +243,7 @@ def domain_init(
     # Load and render all templates from the bundled domain_repo directory
     templates_pkg = importlib.resources.files("datameshy").joinpath("templates/domain_repo")
     created_files: list[str] = []
+    jinja_env = Environment(loader=BaseLoader(), keep_trailing_newline=True)
 
     def _render_dir(pkg_dir, dest_dir: Path) -> None:
         """Recursively render a package resource directory into dest_dir."""
@@ -250,16 +252,13 @@ def domain_init(
             if entry.is_dir():
                 _render_dir(entry, dest_dir / entry_name)
             else:
-                # It's a file — render if .j2, otherwise copy
                 dest_name = entry_name[:-3] if entry_name.endswith(".j2") else entry_name
                 dest_file = dest_dir / dest_name
                 dest_file.parent.mkdir(parents=True, exist_ok=True)
 
                 raw = entry.read_text(encoding="utf-8")
                 if entry_name.endswith(".j2"):
-                    env = Environment(loader=BaseLoader(), keep_trailing_newline=True)
-                    template = env.from_string(raw)
-                    content = template.render(**template_vars)
+                    content = jinja_env.from_string(raw).render(**template_vars)
                 else:
                     content = raw
                 dest_file.write_text(content, encoding="utf-8")
@@ -303,6 +302,9 @@ def domain_upgrade(
       datameshy domain upgrade --to 1.1.0 --dir ./data-meshy-sales
     """
     import tomllib
+
+    if not re.match(r"^\d+\.\d+\.\d+$", to):
+        raise typer.BadParameter(f"--to must be semver X.Y.Z (got: {to}).")
 
     repo_root = (dir or Path.cwd()).resolve()
     toml_path = repo_root / ".datameshy.toml"

--- a/cli/datameshy/commands/domain.py
+++ b/cli/datameshy/commands/domain.py
@@ -1,13 +1,16 @@
 """CLI commands for domain management.
 
 Commands:
-  datameshy domain onboard  — provision a new domain into the mesh
+  datameshy domain onboard  — provision a new domain into the mesh (platform-team command)
+  datameshy domain init     — scaffold a new isolated domain repo (domain-team command)
+  datameshy domain upgrade  — upgrade an existing domain repo to a new platform version
   datameshy domain list     — list all onboarded domains
   datameshy domain status   — show domain details and product count
 """
 
 from __future__ import annotations
 
+import importlib.resources
 import re
 import shutil
 from pathlib import Path
@@ -192,6 +195,185 @@ def domain_onboard(
         "  2. Create your first data product: [cyan]datameshy product create --spec product.yaml[/cyan]\n"
         "  3. List all domains: [cyan]datameshy domain list[/cyan]"
     )
+
+
+@app.command("init")
+def domain_init(
+    name: Annotated[str, typer.Option("--name", help="Domain name (alphanumeric + hyphens, max 32 chars).")],
+    account_id: Annotated[str, typer.Option("--account-id", help="12-digit AWS account ID for the domain.")],
+    owner: Annotated[str, typer.Option("--owner", help="Domain owner email address.")],
+    platform_version: Annotated[str, typer.Option("--platform-version", help="Platform version to pin.")] = "1.0.0",
+    output_dir: Annotated[Optional[Path], typer.Option("--output-dir", help="Directory to scaffold repo into.")] = None,
+) -> None:
+    """Scaffold a new isolated domain repo for a domain team.
+
+    This command renders all Jinja2 templates from the bundled domain_repo
+    scaffold and writes the resulting files into a new directory named
+    `data-meshy-{name}` under the specified output directory.
+
+    It does NOT run terraform or emit events — it only creates files.
+
+    Example:
+
+    \b
+      datameshy domain init \\
+        --name sales \\
+        --account-id 123456789012 \\
+        --owner sales-team@company.com
+    """
+    # Validate inputs
+    _validate_domain_name(name)
+    if not re.match(r"^\d{12}$", account_id):
+        raise typer.BadParameter(f"account-id must be a 12-digit AWS account ID (got: {account_id}).")
+    if "@" not in owner:
+        raise typer.BadParameter(f"owner must be a valid email address (got: {owner}).")
+
+    from jinja2 import Environment, BaseLoader
+
+    dest_root = (output_dir or Path.cwd()) / f"data-meshy-{name}"
+
+    template_vars = {
+        "domain": name,
+        "account_id": account_id,
+        "owner": owner,
+        "platform_version": platform_version,
+    }
+
+    # Load and render all templates from the bundled domain_repo directory
+    templates_pkg = importlib.resources.files("datameshy").joinpath("templates/domain_repo")
+    created_files: list[str] = []
+
+    def _render_dir(pkg_dir, dest_dir: Path) -> None:
+        """Recursively render a package resource directory into dest_dir."""
+        for entry in pkg_dir.iterdir():
+            entry_name = entry.name
+            if entry.is_dir():
+                _render_dir(entry, dest_dir / entry_name)
+            else:
+                # It's a file — render if .j2, otherwise copy
+                dest_name = entry_name[:-3] if entry_name.endswith(".j2") else entry_name
+                dest_file = dest_dir / dest_name
+                dest_file.parent.mkdir(parents=True, exist_ok=True)
+
+                raw = entry.read_text(encoding="utf-8")
+                if entry_name.endswith(".j2"):
+                    env = Environment(loader=BaseLoader(), keep_trailing_newline=True)
+                    template = env.from_string(raw)
+                    content = template.render(**template_vars)
+                else:
+                    content = raw
+                dest_file.write_text(content, encoding="utf-8")
+                created_files.append(str(dest_file.relative_to(dest_root.parent)))
+
+    _render_dir(templates_pkg, dest_root)
+
+    # Print summary
+    console.print(f"\n[bold green]Domain repo scaffolded:[/bold green] {dest_root}")
+    console.print(f"\n[bold]Files created ({len(created_files)}):[/bold]")
+    for f in sorted(created_files):
+        console.print(f"  [dim]{f}[/dim]")
+
+    console.print(
+        f"\n[bold]Next steps:[/bold]\n"
+        f"  1. [cyan]cd {dest_root}[/cyan]\n"
+        f"  2. Create a GitHub repo named [cyan]data-meshy-{name}[/cyan] and push\n"
+        f"  3. Configure OIDC in the platform: ask your platform team\n"
+        f"  4. Bootstrap infra: [cyan]cd infra && terraform init && terraform apply[/cyan]\n"
+        f"  5. Add your first data product under [cyan]products/[/cyan]\n"
+        f"\nPinned platform version: [yellow]{platform_version}[/yellow]"
+    )
+
+
+@app.command("upgrade")
+def domain_upgrade(
+    to: Annotated[str, typer.Option("--to", help="Target platform version (e.g. 1.1.0).")],
+    dir: Annotated[Optional[Path], typer.Option("--dir", help="Path to existing domain repo root.")] = None,
+) -> None:
+    """Upgrade an existing domain repo to a new platform version.
+
+    Reads `.datameshy.toml`, updates the pinned `[platform] version`,
+    and replaces version references in `infra/main.tf` and all
+    `.github/workflows/*.yml` files.
+
+    Safe to run multiple times — the operation is idempotent.
+
+    Example:
+
+    \b
+      datameshy domain upgrade --to 1.1.0 --dir ./data-meshy-sales
+    """
+    import tomllib
+
+    repo_root = (dir or Path.cwd()).resolve()
+    toml_path = repo_root / ".datameshy.toml"
+
+    if not toml_path.is_file():
+        console.print("[red]Not a datameshy domain repo:[/red] .datameshy.toml not found.")
+        raise typer.Exit(code=1)
+
+    toml_text = toml_path.read_text(encoding="utf-8")
+
+    try:
+        config = tomllib.loads(toml_text)
+    except Exception as exc:
+        console.print(f"[red]Failed to parse .datameshy.toml:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    old_version: str = config.get("platform", {}).get("version", "")
+    if not old_version:
+        console.print("[red].datameshy.toml is missing [platform] version field.[/red]")
+        raise typer.Exit(code=1)
+
+    if old_version == to:
+        console.print(f"[yellow]Already at version {to} — nothing to do.[/yellow]")
+        return
+
+    changed_lines: list[str] = []
+
+    # 1. Update .datameshy.toml
+    new_toml_text = toml_text.replace(
+        f'version = "{old_version}"',
+        f'version = "{to}"',
+        1,  # replace only the first occurrence (platform version)
+    )
+    if new_toml_text != toml_text:
+        toml_path.write_text(new_toml_text, encoding="utf-8")
+        changed_lines.append(f"  .datameshy.toml  : version {old_version!r} -> {to!r}")
+
+    # 2. Update infra/main.tf
+    main_tf = repo_root / "infra" / "main.tf"
+    if main_tf.is_file():
+        tf_text = main_tf.read_text(encoding="utf-8")
+        new_tf_text = re.sub(
+            rf"\?ref=v{re.escape(old_version)}",
+            f"?ref=v{to}",
+            tf_text,
+        )
+        if new_tf_text != tf_text:
+            main_tf.write_text(new_tf_text, encoding="utf-8")
+            changed_lines.append(f"  infra/main.tf    : ?ref=v{old_version} -> ?ref=v{to}")
+
+    # 3. Update .github/workflows/*.yml
+    workflows_dir = repo_root / ".github" / "workflows"
+    if workflows_dir.is_dir():
+        for yml_file in sorted(workflows_dir.glob("*.yml")):
+            wf_text = yml_file.read_text(encoding="utf-8")
+            new_wf_text = re.sub(
+                rf"@v{re.escape(old_version)}",
+                f"@v{to}",
+                wf_text,
+            )
+            if new_wf_text != wf_text:
+                yml_file.write_text(new_wf_text, encoding="utf-8")
+                rel = yml_file.relative_to(repo_root)
+                changed_lines.append(f"  {rel}  : @v{old_version} -> @v{to}")
+
+    if changed_lines:
+        console.print(f"\n[bold green]Upgraded[/bold green] {old_version} -> {to}:")
+        for line in changed_lines:
+            console.print(line)
+    else:
+        console.print(f"[yellow]No version strings found to update for {old_version} -> {to}.[/yellow]")
 
 
 @app.command("list")

--- a/cli/datameshy/lib/spec_parser.py
+++ b/cli/datameshy/lib/spec_parser.py
@@ -6,6 +6,7 @@ detects breaking changes between two versions of a spec.
 
 from __future__ import annotations
 
+import importlib.resources
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -170,18 +171,14 @@ def _load_schema(schema_path: str | None = None) -> dict[str, Any]:
         with open(schema_path, encoding="utf-8") as fh:
             return json.load(fh)
 
-    # Try to locate schemas/product_spec.json relative to repo root
-    # (walks up from this file looking for schemas/)
-    current = Path(__file__).resolve()
-    for _ in range(10):
-        candidate = current / "schemas" / "product_spec.json"
-        if candidate.is_file():
-            import json
-            with open(candidate, encoding="utf-8") as fh:
-                return json.load(fh)
-        current = current.parent
-        if current == current.parent:
-            break
+    # Try to load the bundled schema via importlib.resources (works from installed package)
+    try:
+        import json
+        schema_ref = importlib.resources.files("datameshy").joinpath("schemas/product_spec.json")
+        schema_text = schema_ref.read_text(encoding="utf-8")
+        return json.loads(schema_text)
+    except (FileNotFoundError, TypeError, AttributeError):
+        pass
 
     return _INLINE_SCHEMA
 

--- a/cli/datameshy/schemas/product_spec.json
+++ b/cli/datameshy/schemas/product_spec.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/data-meshy/schemas/product_spec.json",
+  "title": "DataMeshy Product Specification",
+  "description": "JSON Schema (Draft 7) for validating product.yaml data product contracts. Used by CI (Stream 4) and the CLI spec_parser.",
+  "type": "object",
+  "required": ["schema_version", "product", "sla", "schema", "quality", "classification"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "description": "Monotonically increasing integer version of this product spec. Required by ADR-009.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "product": {
+      "type": "object",
+      "required": ["name", "domain", "owner"],
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "description": "Unique product name within the domain (snake_case).",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "domain": {
+          "description": "Domain name this product belongs to. Must match a registered domain in mesh-domains.",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9_-]*$"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "description": "Product owner email address.",
+          "type": "string",
+          "format": "email"
+        },
+        "contact_channel": {
+          "type": "string"
+        }
+      }
+    },
+    "sla": {
+      "type": "object",
+      "required": ["refresh_frequency"],
+      "additionalProperties": true,
+      "properties": {
+        "refresh_frequency": {
+          "description": "How often data is refreshed.",
+          "type": "string",
+          "enum": ["hourly", "daily", "weekly", "monthly", "on_demand"]
+        },
+        "freshness_target": {
+          "description": "Maximum acceptable data age (e.g., '24 hours', '4 hours', '7 days').",
+          "type": "string",
+          "minLength": 1
+        },
+        "availability": {
+          "description": "Availability SLA target (e.g., '99.9%').",
+          "type": "string"
+        }
+      }
+    },
+    "schema": {
+      "type": "object",
+      "required": ["columns"],
+      "additionalProperties": true,
+      "properties": {
+        "format": {
+          "description": "Table format. Always 'iceberg' for mesh-published products.",
+          "type": "string",
+          "enum": ["iceberg"]
+        },
+        "columns": {
+          "description": "List of columns in the gold (published) layer.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["name", "type", "pii", "nullable"],
+            "additionalProperties": true,
+            "properties": {
+              "name": {
+                "description": "Column name (snake_case).",
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[a-z][a-z0-9_]*$"
+              },
+              "type": {
+                "description": "Column data type (e.g., string, integer, decimal(10,2), date, timestamp).",
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              },
+              "pii": {
+                "description": "Whether this column contains personally identifiable information.",
+                "type": "boolean"
+              },
+              "nullable": {
+                "description": "Whether this column can contain null values.",
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "partition_by": {
+          "description": "Iceberg partitioning strategy.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["column"],
+            "additionalProperties": true,
+            "properties": {
+              "column": {
+                "type": "string",
+                "minLength": 1
+              },
+              "transform": {
+                "type": "string",
+                "enum": ["identity", "year", "month", "day", "hour", "bucket", "truncate"]
+              }
+            }
+          }
+        }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "required": ["rules"],
+      "additionalProperties": true,
+      "properties": {
+        "rules": {
+          "description": "List of Glue Data Quality (DQDL) rules that must pass before publish.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["name", "rule"],
+            "additionalProperties": true,
+            "properties": {
+              "name": {
+                "description": "Human-readable rule name (used in alerts and reports).",
+                "type": "string",
+                "minLength": 1
+              },
+              "rule": {
+                "description": "DQDL rule expression (e.g., 'IsComplete \\'order_id\\'').",
+                "type": "string",
+                "minLength": 1
+              },
+              "threshold": {
+                "description": "Optional pass threshold (0.0–1.0). Defaults to Glue DQ default if not set.",
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0
+              }
+            }
+          }
+        },
+        "minimum_quality_score": {
+          "description": "Minimum overall quality score (0–100) for the pipeline to publish.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "tags": {
+      "description": "Tags for catalog discoverability and LF-Tag–based access control.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "classification": {
+      "description": "Data classification level. Determines default access policy and approval requirements.",
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted"]
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["system"],
+            "additionalProperties": true,
+            "properties": {
+              "system": {
+                "description": "Name of the source system.",
+                "type": "string",
+                "minLength": 1
+              },
+              "table": {
+                "description": "Source table name (schema.table format for JDBC sources).",
+                "type": "string"
+              },
+              "endpoint": {
+                "description": "API endpoint path for API sources.",
+                "type": "string"
+              },
+              "credentials_secret_arn": {
+                "description": "AWS Secrets Manager ARN for source credentials.",
+                "type": "string",
+                "pattern": "^arn:aws:secretsmanager:"
+              }
+            }
+          }
+        },
+        "pipeline_type": {
+          "description": "Pipeline technology used to produce this product.",
+          "type": "string",
+          "enum": ["glue_step_functions", "dbt", "lambda", "emr", "flink", "external"]
+        }
+      }
+    }
+  }
+}

--- a/cli/datameshy/templates/domain_repo/.datameshy.toml.j2
+++ b/cli/datameshy/templates/domain_repo/.datameshy.toml.j2
@@ -1,0 +1,9 @@
+[platform]
+version = "{{ platform_version }}"
+repo = "JawaharRamis/data-meshy-platform"
+
+[domain]
+name = "{{ domain }}"
+account_id = "{{ account_id }}"
+aws_region = "us-east-1"
+owner = "{{ owner }}"

--- a/cli/datameshy/templates/domain_repo/.github/workflows/infra-apply.yml.j2
+++ b/cli/datameshy/templates/domain_repo/.github/workflows/infra-apply.yml.j2
@@ -1,0 +1,19 @@
+name: Infra Apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/**"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  apply:
+    uses: JawaharRamis/data-meshy-platform/.github/workflows/reusable-infra-apply.yml@v{{ platform_version }}
+    with:
+      domain: {{ domain }}
+      working_directory: infra
+    secrets: inherit

--- a/cli/datameshy/templates/domain_repo/.github/workflows/infra-plan.yml.j2
+++ b/cli/datameshy/templates/domain_repo/.github/workflows/infra-plan.yml.j2
@@ -1,0 +1,20 @@
+name: Infra Plan
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "infra/**"
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  plan:
+    uses: JawaharRamis/data-meshy-platform/.github/workflows/reusable-infra-plan.yml@v{{ platform_version }}
+    with:
+      domain: {{ domain }}
+      working_directory: infra
+    secrets: inherit

--- a/cli/datameshy/templates/domain_repo/.github/workflows/product-validate.yml.j2
+++ b/cli/datameshy/templates/domain_repo/.github/workflows/product-validate.yml.j2
@@ -1,0 +1,19 @@
+name: Product Validate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "products/**"
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    uses: JawaharRamis/data-meshy-platform/.github/workflows/reusable-product-validate.yml@v{{ platform_version }}
+    with:
+      domain: {{ domain }}
+    secrets: inherit

--- a/cli/datameshy/templates/domain_repo/README.md.j2
+++ b/cli/datameshy/templates/domain_repo/README.md.j2
@@ -1,0 +1,43 @@
+# data-meshy-{{ domain }}
+
+Domain repo for the **{{ domain }}** data domain, managed by the Data Meshy platform.
+
+## Owner
+
+{{ owner }}
+
+## Setup
+
+### Prerequisites
+
+- Terraform >= 1.6
+- AWS CLI configured with credentials for account `{{ account_id }}`
+- Access to the `datameshy` CLI (`pip install datameshy`)
+
+### Bootstrap infrastructure
+
+```bash
+cd infra
+terraform init
+terraform plan
+terraform apply
+```
+
+### Add a data product
+
+1. Create a product spec under `products/<product_name>/product.yaml`
+2. Open a pull request — the `product-validate` workflow validates the spec automatically
+3. Merge to `main` to publish
+
+## Workflows
+
+| Workflow | Trigger | Action |
+|---|---|---|
+| `infra-plan.yml` | PR touching `infra/` | Runs `terraform plan`, comments on PR |
+| `infra-apply.yml` | Push to `main` touching `infra/` | Runs `terraform apply` |
+| `product-validate.yml` | PR touching `products/` | Validates product specs |
+
+## Platform version
+
+This repo targets platform version **{{ platform_version }}**.
+To upgrade: `datameshy domain upgrade --to <new_version>`

--- a/cli/datameshy/templates/domain_repo/infra/backend.tf.j2
+++ b/cli/datameshy/templates/domain_repo/infra/backend.tf.j2
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket = "datameshy-platform-tfstate"
+    key    = "{{ domain }}/terraform.tfstate"
+    region = "us-east-1"
+
+    dynamodb_table = "datameshy-tfstate-locks"
+    encrypt        = true
+  }
+}

--- a/cli/datameshy/templates/domain_repo/infra/main.tf.j2
+++ b/cli/datameshy/templates/domain_repo/infra/main.tf.j2
@@ -1,0 +1,8 @@
+module "domain_account" {
+  source = "git::https://github.com/JawaharRamis/data-meshy-platform.git//infra/modules/domain-account?ref=v{{ platform_version }}"
+
+  domain     = var.domain
+  account_id = var.account_id
+  owner      = var.owner
+  aws_region = var.aws_region
+}

--- a/cli/datameshy/templates/domain_repo/infra/outputs.tf.j2
+++ b/cli/datameshy/templates/domain_repo/infra/outputs.tf.j2
@@ -1,0 +1,14 @@
+output "raw_bucket" {
+  description = "S3 bucket for raw (bronze) layer data."
+  value       = module.domain_account.raw_bucket
+}
+
+output "gold_bucket" {
+  description = "S3 bucket for gold layer (published data products)."
+  value       = module.domain_account.gold_bucket
+}
+
+output "glue_catalog_db_gold" {
+  description = "Glue catalog database name for gold layer tables."
+  value       = module.domain_account.glue_catalog_db_gold
+}

--- a/cli/datameshy/templates/domain_repo/infra/terraform.tfvars.j2
+++ b/cli/datameshy/templates/domain_repo/infra/terraform.tfvars.j2
@@ -1,0 +1,4 @@
+domain     = "{{ domain }}"
+account_id = "{{ account_id }}"
+owner      = "{{ owner }}"
+aws_region = "us-east-1"

--- a/cli/datameshy/templates/domain_repo/infra/variables.tf.j2
+++ b/cli/datameshy/templates/domain_repo/infra/variables.tf.j2
@@ -1,0 +1,20 @@
+variable "domain" {
+  description = "Domain name for this data mesh domain."
+  type        = string
+}
+
+variable "account_id" {
+  description = "AWS account ID for this domain."
+  type        = string
+}
+
+variable "owner" {
+  description = "Owner email address for this domain."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region to deploy resources in."
+  type        = string
+  default     = "us-east-1"
+}

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyyaml >= 6.0",
     "jsonschema >= 4.21",
     "rich >= 13.0",
+    "jinja2 >= 3.1",
 ]
 
 [project.optional-dependencies]
@@ -33,6 +34,10 @@ datameshy = "datameshy.cli:app"
 
 [tool.hatch.build.targets.wheel]
 packages = ["datameshy"]
+artifacts = ["datameshy/schemas/*.json", "datameshy/templates/**/*"]
+
+[tool.setuptools.package-data]
+"datameshy" = ["schemas/*.json", "templates/domain_repo/**/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -36,9 +36,6 @@ datameshy = "datameshy.cli:app"
 packages = ["datameshy"]
 artifacts = ["datameshy/schemas/*.json", "datameshy/templates/**/*"]
 
-[tool.setuptools.package-data]
-"datameshy" = ["schemas/*.json", "templates/domain_repo/**/*"]
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=datameshy --cov-report=term-missing --cov-fail-under=80"

--- a/cli/tests/test_domain_init.py
+++ b/cli/tests/test_domain_init.py
@@ -1,0 +1,317 @@
+"""Tests for domain init and domain upgrade CLI commands."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from datameshy.commands.domain import app, _validate_domain_name
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scaffold(tmp_path: Path, name: str = "test-domain", platform_version: str = "1.0.0") -> Path:
+    """Run domain init and return the scaffolded repo root."""
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--name", name,
+            "--account-id", "123456789012",
+            "--owner", "owner@example.com",
+            "--platform-version", platform_version,
+            "--output-dir", str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, f"domain init failed:\n{result.output}"
+    return tmp_path / f"data-meshy-{name}"
+
+
+# ---------------------------------------------------------------------------
+# domain init: file structure
+# ---------------------------------------------------------------------------
+
+
+class TestDomainInit:
+    """Tests for `datameshy domain init`."""
+
+    EXPECTED_FILES = [
+        ".datameshy.toml",
+        "README.md",
+        "infra/backend.tf",
+        "infra/main.tf",
+        "infra/variables.tf",
+        "infra/outputs.tf",
+        "infra/terraform.tfvars",
+        ".github/workflows/infra-plan.yml",
+        ".github/workflows/infra-apply.yml",
+        ".github/workflows/product-validate.yml",
+    ]
+
+    def test_scaffolds_expected_files(self, tmp_path):
+        """All expected files must be created."""
+        repo = _scaffold(tmp_path)
+        for rel in self.EXPECTED_FILES:
+            assert (repo / rel).is_file(), f"Missing file: {rel}"
+
+    def test_datameshy_toml_content(self, tmp_path):
+        """The .datameshy.toml must follow the shared contract schema."""
+        import tomllib
+
+        repo = _scaffold(tmp_path, name="finance", platform_version="1.2.3")
+        toml_path = repo / ".datameshy.toml"
+        config = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+
+        assert config["platform"]["version"] == "1.2.3"
+        assert config["platform"]["repo"] == "JawaharRamis/data-meshy-platform"
+        assert config["domain"]["name"] == "finance"
+        assert config["domain"]["account_id"] == "123456789012"
+        assert config["domain"]["owner"] == "owner@example.com"
+
+    def test_main_tf_git_source(self, tmp_path):
+        """infra/main.tf must use the agreed git:: module source format."""
+        repo = _scaffold(tmp_path, platform_version="1.0.0")
+        main_tf = (repo / "infra/main.tf").read_text(encoding="utf-8")
+        assert "git::https://github.com/JawaharRamis/data-meshy-platform.git" in main_tf
+        assert "?ref=v1.0.0" in main_tf
+
+    def test_main_tf_module_name(self, tmp_path):
+        """infra/main.tf must reference the domain-account module."""
+        repo = _scaffold(tmp_path)
+        main_tf = (repo / "infra/main.tf").read_text(encoding="utf-8")
+        assert "infra/modules/domain-account" in main_tf
+
+    def test_backend_tf_state_key(self, tmp_path):
+        """infra/backend.tf must use domain name in the state key."""
+        repo = _scaffold(tmp_path, name="marketing")
+        backend_tf = (repo / "infra/backend.tf").read_text(encoding="utf-8")
+        assert 'key    = "marketing/terraform.tfstate"' in backend_tf
+
+    def test_workflow_files_use_platform_version(self, tmp_path):
+        """Workflow files must reference the pinned platform version."""
+        repo = _scaffold(tmp_path, platform_version="2.0.0")
+        for wf in [
+            ".github/workflows/infra-plan.yml",
+            ".github/workflows/infra-apply.yml",
+            ".github/workflows/product-validate.yml",
+        ]:
+            content = (repo / wf).read_text(encoding="utf-8")
+            assert "@v2.0.0" in content, f"{wf} missing @v2.0.0"
+
+    def test_tfvars_contains_domain_values(self, tmp_path):
+        """infra/terraform.tfvars must include domain name and account_id."""
+        repo = _scaffold(tmp_path, name="ops")
+        tfvars = (repo / "infra/terraform.tfvars").read_text(encoding="utf-8")
+        assert 'domain     = "ops"' in tfvars
+        assert 'account_id = "123456789012"' in tfvars
+
+    def test_readme_mentions_domain(self, tmp_path):
+        """README.md must mention the domain name."""
+        repo = _scaffold(tmp_path, name="logistics")
+        readme = (repo / "README.md").read_text(encoding="utf-8")
+        assert "logistics" in readme
+
+    def test_output_dir_default_is_cwd(self, tmp_path, monkeypatch):
+        """Without --output-dir, files are scaffolded into the CWD."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--name", "cwd-domain",
+                "--account-id", "123456789012",
+                "--owner", "owner@example.com",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "data-meshy-cwd-domain" / ".datameshy.toml").is_file()
+
+    def test_invalid_domain_name_raises(self, tmp_path):
+        """An invalid domain name (starts with hyphen) should fail."""
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--name", "-bad-name",
+                "--account-id", "123456789012",
+                "--owner", "owner@example.com",
+                "--output-dir", str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_invalid_account_id_raises(self, tmp_path):
+        """A non-12-digit account ID should fail."""
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--name", "valid-name",
+                "--account-id", "1234",
+                "--owner", "owner@example.com",
+                "--output-dir", str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_invalid_owner_raises(self, tmp_path):
+        """An owner without @ should fail."""
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--name", "valid-name",
+                "--account-id", "123456789012",
+                "--owner", "not-an-email",
+                "--output-dir", str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# domain upgrade
+# ---------------------------------------------------------------------------
+
+
+def _make_domain_repo(tmp_path: Path, version: str = "1.0.0", name: str = "sales") -> Path:
+    """Create a minimal domain repo structure for upgrade tests."""
+    repo = tmp_path / f"data-meshy-{name}"
+
+    (repo / "infra").mkdir(parents=True)
+    (repo / ".github" / "workflows").mkdir(parents=True)
+
+    (repo / ".datameshy.toml").write_text(
+        textwrap.dedent(f"""\
+            [platform]
+            version = "{version}"
+            repo = "JawaharRamis/data-meshy-platform"
+
+            [domain]
+            name = "{name}"
+            account_id = "123456789012"
+            aws_region = "us-east-1"
+            owner = "owner@example.com"
+        """),
+        encoding="utf-8",
+    )
+
+    (repo / "infra" / "main.tf").write_text(
+        textwrap.dedent(f"""\
+            module "domain_account" {{
+              source = "git::https://github.com/JawaharRamis/data-meshy-platform.git//infra/modules/domain-account?ref=v{version}"
+            }}
+        """),
+        encoding="utf-8",
+    )
+
+    for wf_name in ["infra-plan.yml", "infra-apply.yml", "product-validate.yml"]:
+        (repo / ".github" / "workflows" / wf_name).write_text(
+            textwrap.dedent(f"""\
+                jobs:
+                  plan:
+                    uses: JawaharRamis/data-meshy-platform/.github/workflows/reusable-infra-plan.yml@v{version}
+            """),
+            encoding="utf-8",
+        )
+
+    return repo
+
+
+class TestDomainUpgrade:
+    """Tests for `datameshy domain upgrade`."""
+
+    def test_updates_toml_version(self, tmp_path):
+        """After upgrade, .datameshy.toml should contain the new version."""
+        import tomllib
+
+        repo = _make_domain_repo(tmp_path, version="1.0.0")
+        result = runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        assert result.exit_code == 0, result.output
+
+        config = tomllib.loads((repo / ".datameshy.toml").read_text(encoding="utf-8"))
+        assert config["platform"]["version"] == "1.1.0"
+
+    def test_updates_main_tf_ref(self, tmp_path):
+        """After upgrade, infra/main.tf should have the new ?ref= value."""
+        repo = _make_domain_repo(tmp_path, version="1.0.0")
+        runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        main_tf = (repo / "infra" / "main.tf").read_text(encoding="utf-8")
+        assert "?ref=v1.1.0" in main_tf
+        assert "?ref=v1.0.0" not in main_tf
+
+    def test_updates_workflow_versions(self, tmp_path):
+        """After upgrade, all workflow files should reference the new version."""
+        repo = _make_domain_repo(tmp_path, version="1.0.0")
+        runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        for wf_name in ["infra-plan.yml", "infra-apply.yml", "product-validate.yml"]:
+            content = (repo / ".github" / "workflows" / wf_name).read_text(encoding="utf-8")
+            assert "@v1.1.0" in content, f"{wf_name} not updated"
+            assert "@v1.0.0" not in content
+
+    def test_idempotent_when_run_twice(self, tmp_path):
+        """Running upgrade twice produces the same result (idempotent)."""
+        import tomllib
+
+        repo = _make_domain_repo(tmp_path, version="1.0.0")
+        runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        result2 = runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        assert result2.exit_code == 0
+
+        config = tomllib.loads((repo / ".datameshy.toml").read_text(encoding="utf-8"))
+        assert config["platform"]["version"] == "1.1.0"
+
+    def test_already_at_version_exits_cleanly(self, tmp_path):
+        """If already at the target version, upgrade should exit cleanly."""
+        repo = _make_domain_repo(tmp_path, version="2.0.0")
+        result = runner.invoke(app, ["upgrade", "--to", "2.0.0", "--dir", str(repo)])
+        assert result.exit_code == 0
+        assert "nothing to do" in result.output.lower() or "already" in result.output.lower()
+
+    def test_missing_toml_errors(self, tmp_path):
+        """Upgrade on a non-datameshy directory should exit with code 1."""
+        repo = tmp_path / "not-a-domain-repo"
+        repo.mkdir()
+        result = runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        assert result.exit_code == 1
+        assert "datameshy" in result.output.lower() or ".datameshy.toml" in result.output
+
+
+# ---------------------------------------------------------------------------
+# _validate_domain_name unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDomainName:
+    """Tests for the domain name validator."""
+
+    @pytest.mark.parametrize("name", [
+        "sales",
+        "sales-data",
+        "a1",
+        "domain-with-hyphens",
+    ])
+    def test_valid_names(self, name):
+        """Valid domain names should return the name unchanged."""
+        assert _validate_domain_name(name) == name
+
+    @pytest.mark.parametrize("name", [
+        "-invalid",
+        "invalid-",
+        "has spaces",
+        "a" * 33,  # too long
+        "has_underscore",
+    ])
+    def test_invalid_names_raise(self, name):
+        """Invalid domain names should raise BadParameter."""
+        with pytest.raises(typer.BadParameter):
+            _validate_domain_name(name)

--- a/cli/tests/test_domain_init.py
+++ b/cli/tests/test_domain_init.py
@@ -177,6 +177,21 @@ class TestDomainInit:
         )
         assert result.exit_code != 0
 
+    def test_invalid_platform_version_raises(self, tmp_path):
+        """A non-semver platform version should fail."""
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--name", "valid-name",
+                "--account-id", "123456789012",
+                "--owner", "owner@example.com",
+                "--platform-version", "not-semver",
+                "--output-dir", str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+
 
 # ---------------------------------------------------------------------------
 # domain upgrade
@@ -244,7 +259,8 @@ class TestDomainUpgrade:
     def test_updates_main_tf_ref(self, tmp_path):
         """After upgrade, infra/main.tf should have the new ?ref= value."""
         repo = _make_domain_repo(tmp_path, version="1.0.0")
-        runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        result = runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        assert result.exit_code == 0, result.output
         main_tf = (repo / "infra" / "main.tf").read_text(encoding="utf-8")
         assert "?ref=v1.1.0" in main_tf
         assert "?ref=v1.0.0" not in main_tf
@@ -252,7 +268,8 @@ class TestDomainUpgrade:
     def test_updates_workflow_versions(self, tmp_path):
         """After upgrade, all workflow files should reference the new version."""
         repo = _make_domain_repo(tmp_path, version="1.0.0")
-        runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        result = runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
+        assert result.exit_code == 0, result.output
         for wf_name in ["infra-plan.yml", "infra-apply.yml", "product-validate.yml"]:
             content = (repo / ".github" / "workflows" / wf_name).read_text(encoding="utf-8")
             assert "@v1.1.0" in content, f"{wf_name} not updated"
@@ -284,6 +301,16 @@ class TestDomainUpgrade:
         result = runner.invoke(app, ["upgrade", "--to", "1.1.0", "--dir", str(repo)])
         assert result.exit_code == 1
         assert "datameshy" in result.output.lower() or ".datameshy.toml" in result.output
+
+    def test_invalid_to_version_raises(self, tmp_path):
+        """A non-semver --to version should fail before touching files."""
+        repo = _make_domain_repo(tmp_path, version="1.0.0")
+        result = runner.invoke(app, ["upgrade", "--to", "not-a-version", "--dir", str(repo)])
+        assert result.exit_code != 0
+        # File should be untouched
+        import tomllib
+        config = tomllib.loads((repo / ".datameshy.toml").read_text(encoding="utf-8"))
+        assert config["platform"]["version"] == "1.0.0"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implements `datameshy domain init` — scaffolds an isolated domain repo from bundled Jinja2 templates (`.datameshy.toml`, `infra/`, `.github/workflows/`, `README.md`)
- Implements `datameshy domain upgrade` — updates pinned platform version in `.datameshy.toml`, `infra/main.tf`, and all workflow files; idempotent
- Fixes `_render_dir` bug: was using `hasattr(entry, "iterdir")` to detect directories (always True for all `Traversable` objects) — replaced with `entry.is_dir()`, which fixes `NotADirectoryError` on Windows
- Updates module docstring to document all 5 commands (onboard, init, upgrade, list, status)

## Tests

`cli/tests/test_domain_init.py` — 27 new tests:
- `TestDomainInit`: file structure, `.datameshy.toml` schema contract, `infra/main.tf` git source format, `backend.tf` state key, workflow version pinning, `terraform.tfvars` values, README content, CWD default, validation edge cases
- `TestDomainUpgrade`: toml update, `main.tf` ref update, workflow update, idempotency, already-at-version, missing toml error
- `TestValidateDomainName`: valid/invalid parametrized cases

Full suite: **88% coverage, 142/143 passing** (one pre-existing `test_minimal_valid_spec` failure unrelated to this stream).

## Shared Contract Adherence

Scaffolded repo layout matches the contract in `plan/phases/pre-phase-3/README.md`. TF module source uses `git::https://github.com/JawaharRamis/data-meshy-platform.git//infra/modules/domain-account?ref=v{version}`. `.datameshy.toml` schema matches the agreed format.

## Test plan
- [ ] `cd cli && python -m pytest tests/test_domain_init.py -v`
- [ ] `datameshy domain init --name test --account-id 123456789012 --owner test@test.com --output-dir /tmp` — verify scaffolded repo
- [ ] `datameshy domain upgrade --to 1.1.0 --dir /tmp/data-meshy-test` — verify version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)