### PR TITLE
Phase 3 Stream 2: Product lifecycle — deprecate, rollback, import

### DIFF
--- a/cli/datameshy/commands/product.py
+++ b/cli/datameshy/commands/product.py
@@ -472,6 +472,14 @@ def product_deprecate(
             )
             raise typer.Exit(code=1)
 
+        # HIGH 1: Ownership check — only the product owner or a MeshAdmin may deprecate
+        sts_client = session.client("sts")
+        caller_arn = sts_client.get_caller_identity()["Arn"]
+        product_owner = item.get("owner", "")
+        if caller_arn != product_owner and "MeshAdminRole" not in caller_arn:
+            console.print(f"[red]Authorization failed: caller is not the owner of '{domain}/{product_name}'.[/red]")
+            raise typer.Exit(code=1)
+
         # 2. Compute sunset_date
         sunset_date = (datetime.now(timezone.utc) + timedelta(days=sunset_days)).strftime("%Y-%m-%d")
 
@@ -818,6 +826,18 @@ def product_import(
             )
             raise typer.Exit(code=1)
         console.print(f"  [green]Iceberg table confirmed.[/green]")
+
+        # HIGH 2: Verify table S3 location belongs to the domain's gold bucket
+        sts_client = session.client("sts")
+        account_id = sts_client.get_caller_identity()["Account"]
+        expected_prefix = f"s3://{domain_name}-gold-{account_id}/"
+        table_location = glue_table_obj.get("StorageDescriptor", {}).get("Location", "")
+        if not table_location.startswith(expected_prefix):
+            console.print(
+                f"[red]Table location '{table_location}' does not belong to this domain's gold bucket "
+                f"(expected prefix: '{expected_prefix}').[/red]"
+            )
+            raise typer.Exit(code=1)
 
         # 4. Apply LF-Tags (best-effort)
         if lf_grantor_role_arn:

--- a/cli/datameshy/commands/product.py
+++ b/cli/datameshy/commands/product.py
@@ -1,14 +1,18 @@
 """CLI commands for data product management.
 
 Commands:
-  datameshy product create   — provision a new data product from a spec
-  datameshy product refresh  — trigger a pipeline run for a product
-  datameshy product status   — show product metadata and quality info
+  datameshy product create    — provision a new data product from a spec
+  datameshy product refresh   — trigger a pipeline run for a product
+  datameshy product status    — show product metadata and quality info
+  datameshy product deprecate — mark a product DEPRECATED with a sunset date
+  datameshy product rollback  — restore gold table to a prior Iceberg snapshot
+  datameshy product import    — register an existing Glue Iceberg table as a mesh product
 """
 
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -16,7 +20,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-app = typer.Typer(help="Manage data products (create, refresh, status).")
+app = typer.Typer(help="Manage data products (create, refresh, status, deprecate, rollback, import).")
 console = Console()
 
 _PRODUCTS_TABLE = "mesh-products"
@@ -372,6 +376,12 @@ def product_status(
         tbl.add_row("Name", item.get("product_name", name))
         tbl.add_row("Owner", item.get("owner", "-"))
         tbl.add_row("Status", item.get("status", "-"))
+        if item.get("sunset_date"):
+            tbl.add_row("Sunset Date", item["sunset_date"])
+        if item.get("retired_at"):
+            tbl.add_row("Retired At", item["retired_at"])
+        if item.get("import_source"):
+            tbl.add_row("Import Source", item["import_source"])
         tbl.add_row("Schema Version", str(item.get("schema_version", "-")))
         tbl.add_row("Last Refresh", item.get("last_refresh_at", "Never"))
         tbl.add_row("Last Quality Score", str(item.get("last_quality_score", "-")))
@@ -385,4 +395,505 @@ def product_status(
         raise
     except Exception as exc:
         console.print(f"[red]Error fetching product status:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+
+@app.command("deprecate")
+def product_deprecate(
+    ctx: typer.Context,
+    product_ref: Annotated[str, typer.Argument(help="Product reference as <domain>/<product>.")],
+    sunset_days: Annotated[
+        int,
+        typer.Option("--sunset-days", help="Number of days until the product is retired."),
+    ],
+    event_bus_arn: Annotated[
+        Optional[str],
+        typer.Option("--event-bus-arn", help="Central EventBridge event bus ARN.", envvar="MESH_EVENT_BUS_ARN"),
+    ] = None,
+    retirement_lambda_arn: Annotated[
+        Optional[str],
+        typer.Option("--retirement-lambda-arn", help="ARN of the retirement Lambda.", envvar="MESH_RETIREMENT_LAMBDA_ARN"),
+    ] = None,
+    scheduler_role_arn: Annotated[
+        Optional[str],
+        typer.Option("--scheduler-role-arn", help="IAM role ARN for EventBridge Scheduler.", envvar="MESH_SCHEDULER_ROLE_ARN"),
+    ] = None,
+) -> None:
+    """Mark a data product as DEPRECATED with a computed sunset date.
+
+    This command will:
+
+    \b
+    1. Fetch the product from mesh-products — rejects if status is not ACTIVE
+    2. Compute sunset_date = today + sunset_days
+    3. Write status=DEPRECATED, sunset_date, sunset_days to DynamoDB
+    4. Emit ProductDeprecated event with breaking=true and sunset_date
+    5. Create an EventBridge Scheduler one-shot rule at sunset_date targeting the retirement Lambda
+
+    Example:
+
+    \b
+      datameshy product deprecate sales/customer_orders --sunset-days 90
+    """
+    if "/" not in product_ref:
+        console.print("[red]product_ref must be in the format <domain>/<product>.[/red]")
+        raise typer.Exit(code=1)
+
+    domain, product_name = product_ref.split("/", 1)
+    product_id = f"{domain}#{product_name}"
+
+    try:
+        session = _get_session_from_ctx(ctx)
+        dynamodb = session.resource("dynamodb")
+        products_table = dynamodb.Table(_PRODUCTS_TABLE)
+
+        # 1. Fetch product
+        response = products_table.get_item(Key={"product_id": product_id})
+        item = response.get("Item")
+        if not item:
+            console.print(f"[red]Product '{domain}/{product_name}' not found in mesh-products.[/red]")
+            raise typer.Exit(code=1)
+
+        current_status = item.get("status", "")
+        if current_status == "DEPRECATED":
+            console.print(
+                f"[red]Product '{domain}/{product_name}' is already DEPRECATED.[/red]\n"
+                f"Sunset date: {item.get('sunset_date', 'unknown')}"
+            )
+            raise typer.Exit(code=1)
+        if current_status == "RETIRED":
+            console.print(
+                f"[red]Cannot deprecate '{domain}/{product_name}': product is already RETIRED.[/red]"
+            )
+            raise typer.Exit(code=1)
+        if current_status not in ("ACTIVE", "PROVISIONED"):
+            console.print(
+                f"[red]Product '{domain}/{product_name}' is not in a depreciable state (status={current_status}).[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        # 2. Compute sunset_date
+        sunset_date = (datetime.now(timezone.utc) + timedelta(days=sunset_days)).strftime("%Y-%m-%d")
+
+        # 3. Update DynamoDB
+        products_table.update_item(
+            Key={"product_id": product_id},
+            UpdateExpression=(
+                "SET #s = :deprecated, sunset_date = :sd, sunset_days = :sdays, deprecated_at = :now"
+            ),
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":deprecated": "DEPRECATED",
+                ":sd": sunset_date,
+                ":sdays": sunset_days,
+                ":now": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+        )
+        console.print(f"[green]Product '{domain}/{product_name}' marked DEPRECATED.[/green]")
+        console.print(f"  Sunset date: {sunset_date} ({sunset_days} days from today)")
+
+        # 4. Emit ProductDeprecated event
+        if event_bus_arn:
+            try:
+                from datameshy.lib.aws_client import put_mesh_event
+
+                put_mesh_event(
+                    session=session,
+                    event_bus_arn=event_bus_arn,
+                    event_type="ProductDeprecated",
+                    payload={
+                        "domain": domain,
+                        "product_name": product_name,
+                        "product_id": product_id,
+                        "sunset_date": sunset_date,
+                        "sunset_days": sunset_days,
+                        "breaking": True,
+                    },
+                )
+                console.print("[green]ProductDeprecated event emitted.[/green]")
+            except Exception as exc:
+                console.print(f"[yellow]Warning: could not emit ProductDeprecated event: {exc}[/yellow]")
+
+        # 5. Create EventBridge Scheduler one-shot rule at sunset_date
+        if retirement_lambda_arn:
+            try:
+                import boto3
+                import json as _json
+
+                scheduler = boto3.client("scheduler", region_name=session.region_name or "us-east-1")
+                schedule_name = f"retire-{domain}-{product_name}"
+                # AT expression: at(yyyy-MM-ddTHH:mm:ss) in UTC
+                at_expr = f"at({sunset_date}T00:00:00)"
+
+                sched_kwargs = dict(
+                    Name=schedule_name,
+                    ScheduleExpression=at_expr,
+                    ScheduleExpressionTimezone="UTC",
+                    FlexibleTimeWindow={"Mode": "OFF"},
+                    Target={
+                        "Arn": retirement_lambda_arn,
+                        "Input": _json.dumps({"product_id": product_id, "domain": domain, "product_name": product_name}),
+                        **({"RoleArn": scheduler_role_arn} if scheduler_role_arn else {}),
+                    },
+                    ActionAfterCompletion="DELETE",
+                )
+                scheduler.create_schedule(**sched_kwargs)
+                console.print(f"[green]Retirement scheduler rule created: {schedule_name}[/green]")
+            except Exception as exc:
+                console.print(f"[yellow]Warning: could not create retirement scheduler rule: {exc}[/yellow]")
+
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error deprecating product:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+
+@app.command("rollback")
+def product_rollback(
+    ctx: typer.Context,
+    product_ref: Annotated[str, typer.Argument(help="Product reference as <domain>/<product>.")],
+    to_snapshot: Annotated[
+        Optional[int],
+        typer.Option("--to-snapshot", help="Iceberg snapshot ID to roll back to."),
+    ] = None,
+    list_snapshots: Annotated[
+        bool,
+        typer.Option("--list-snapshots", help="List available Iceberg snapshots instead of rolling back."),
+    ] = False,
+    glue_job_name: Annotated[
+        Optional[str],
+        typer.Option("--glue-job-name", help="Name of the Glue rollback job.", envvar="MESH_ROLLBACK_GLUE_JOB"),
+    ] = None,
+    event_bus_arn: Annotated[
+        Optional[str],
+        typer.Option("--event-bus-arn", help="Central EventBridge event bus ARN.", envvar="MESH_EVENT_BUS_ARN"),
+    ] = None,
+) -> None:
+    """Restore a gold Iceberg table to a prior snapshot via Glue time travel.
+
+    This command will:
+
+    \b
+    1. Validate product exists and is not DEPRECATED or RETIRED
+    2a. With --list-snapshots: show available Iceberg snapshots
+    2b. With --to-snapshot <id>: acquire pipeline lock, start Glue rollback job, release lock
+    3. Emit ProductRefreshed event and update row_count/last_refreshed in mesh-products
+
+    Examples:
+
+    \b
+      datameshy product rollback sales/customer_orders --list-snapshots
+      datameshy product rollback sales/customer_orders --to-snapshot 8765309
+    """
+    if "/" not in product_ref:
+        console.print("[red]product_ref must be in the format <domain>/<product>.[/red]")
+        raise typer.Exit(code=1)
+
+    if not list_snapshots and to_snapshot is None:
+        console.print("[red]Provide --to-snapshot <id> or --list-snapshots.[/red]")
+        raise typer.Exit(code=1)
+
+    domain, product_name = product_ref.split("/", 1)
+    product_id = f"{domain}#{product_name}"
+
+    try:
+        session = _get_session_from_ctx(ctx)
+        dynamodb = session.resource("dynamodb")
+        products_table = dynamodb.Table(_PRODUCTS_TABLE)
+
+        # 1. Fetch product
+        response = products_table.get_item(Key={"product_id": product_id})
+        item = response.get("Item")
+        if not item:
+            console.print(f"[red]Product '{domain}/{product_name}' not found in mesh-products.[/red]")
+            raise typer.Exit(code=1)
+
+        current_status = item.get("status", "")
+        if current_status in ("DEPRECATED", "RETIRED"):
+            console.print(
+                f"[red]Rollback blocked: product '{domain}/{product_name}' has status={current_status}.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        glue_db = item.get("glue_catalog_db_gold", f"{domain}_gold")
+        table_name = product_name
+
+        if list_snapshots:
+            # List snapshots via Glue/Athena query
+            console.print(f"\n[bold]Iceberg snapshots for {domain}/{product_name}:[/bold]")
+            console.print(
+                f"[dim]Run the following Athena query to view snapshots:[/dim]\n"
+                f"  SELECT snapshot_id, committed_at, operation\n"
+                f"  FROM \"{glue_db}\".\"{table_name}$snapshots\"\n"
+                f"  ORDER BY committed_at DESC;"
+            )
+            console.print(
+                "\n[dim]Or use the Glue console / boto3 glue_catalog.{db}.{table}.snapshots table.[/dim]"
+            )
+            return
+
+        # 2. Rollback path: acquire lock, start Glue job, release lock
+        locks_table = dynamodb.Table(_LOCKS_TABLE)
+        lock_response = locks_table.get_item(Key={"product_id": product_id})
+        lock_item = lock_response.get("Item")
+        if lock_item and lock_item.get("locked"):
+            console.print(
+                f"[yellow]Pipeline is already locked for '{domain}/{product_name}'.[/yellow]\n"
+                "Wait for the current operation to finish."
+            )
+            raise typer.Exit(code=1)
+
+        # Acquire lock
+        locks_table.put_item(Item={
+            "product_id": product_id,
+            "locked": True,
+            "operation": "rollback",
+            "snapshot_id": to_snapshot,
+        })
+        console.print(f"[dim]Pipeline lock acquired for {product_id}.[/dim]")
+
+        try:
+            if glue_job_name:
+                glue = session.client("glue")
+                run_response = glue.start_job_run(
+                    JobName=glue_job_name,
+                    Arguments={
+                        "--domain": domain,
+                        "--product_name": product_name,
+                        "--gold_db": glue_db,
+                        "--table_name": table_name,
+                        "--snapshot_id": str(to_snapshot),
+                    },
+                )
+                job_run_id = run_response.get("JobRunId", "unknown")
+                console.print(f"[green]Glue rollback job started.[/green] run_id={job_run_id}")
+            else:
+                console.print(
+                    f"[yellow]No Glue job configured (--glue-job-name not set).[/yellow]\n"
+                    f"  Would execute: CALL glue_catalog.system.rollback_to_snapshot("
+                    f"'{glue_db}.{table_name}', {to_snapshot})"
+                )
+
+            # Update catalog metadata
+            now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            products_table.update_item(
+                Key={"product_id": product_id},
+                UpdateExpression="SET last_refreshed = :now, last_rollback_snapshot = :snap",
+                ExpressionAttributeValues={":now": now_str, ":snap": to_snapshot},
+            )
+
+            # Emit ProductRefreshed event
+            if event_bus_arn:
+                try:
+                    from datameshy.lib.aws_client import put_mesh_event
+
+                    put_mesh_event(
+                        session=session,
+                        event_bus_arn=event_bus_arn,
+                        event_type="ProductRefreshed",
+                        payload={
+                            "domain": domain,
+                            "product_name": product_name,
+                            "product_id": product_id,
+                            "rollback_snapshot_id": to_snapshot,
+                        },
+                    )
+                    console.print("[green]ProductRefreshed event emitted.[/green]")
+                except Exception as exc:
+                    console.print(f"[yellow]Warning: could not emit ProductRefreshed event: {exc}[/yellow]")
+
+            console.print(f"\n[bold green]Rollback to snapshot {to_snapshot} initiated for '{domain}/{product_name}'.[/bold green]")
+
+        finally:
+            # Release lock
+            locks_table.delete_item(Key={"product_id": product_id})
+            console.print(f"[dim]Pipeline lock released for {product_id}.[/dim]")
+
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error during rollback:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+
+@app.command("import")
+def product_import(
+    ctx: typer.Context,
+    spec: Annotated[
+        Path,
+        typer.Option("--spec", help="Path to product.yaml spec file.", exists=True, readable=True),
+    ],
+    glue_database: Annotated[str, typer.Option("--glue-database", help="Glue catalog database name.")],
+    glue_table: Annotated[str, typer.Option("--glue-table", help="Glue catalog table name.")],
+    event_bus_arn: Annotated[
+        Optional[str],
+        typer.Option("--event-bus-arn", help="Central EventBridge event bus ARN.", envvar="MESH_EVENT_BUS_ARN"),
+    ] = None,
+    lf_grantor_role_arn: Annotated[
+        Optional[str],
+        typer.Option("--lf-grantor-role-arn", help="ARN of MeshLFGrantorRole.", envvar="MESH_LF_GRANTOR_ROLE_ARN"),
+    ] = None,
+) -> None:
+    """Register an existing Glue-catalogued Iceberg table as a mesh data product.
+
+    This command will:
+
+    \b
+    1. Validate product.yaml spec (same path as product create)
+    2. Verify the Glue database and table exist in the domain account
+    3. Verify the table is Iceberg format
+    4. Apply LF-Tags (classification, pii, domain) via MeshLFGrantorRole
+    5. Write catalog entry to mesh-products with status=ACTIVE, import_source=glue
+    6. Emit ProductCreated event
+
+    Example:
+
+    \b
+      datameshy product import \\
+        --spec examples/sales-domain/products/revenue_daily/product.yaml \\
+        --glue-database sales_domain --glue-table revenue_daily
+    """
+    from datameshy.lib.spec_parser import SpecValidationError, parse_and_validate
+
+    # 1. Validate spec
+    console.print(f"[bold]Validating spec:[/bold] {spec}")
+    try:
+        parsed = parse_and_validate(str(spec))
+    except SpecValidationError as exc:
+        console.print(f"[red]Spec validation failed:[/red]\n{exc}")
+        raise typer.Exit(code=1) from exc
+    except FileNotFoundError as exc:
+        console.print(f"[red]Spec file not found:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    product_name = parsed["product"]["name"]
+    domain_name = parsed["product"]["domain"]
+    owner = parsed["product"]["owner"]
+    description = parsed["product"].get("description", "")
+    schema_version = parsed.get("schema_version", 1)
+    classification = parsed.get("classification", "internal")
+    has_pii = any(c.get("pii", False) for c in parsed.get("schema", {}).get("columns", []))
+
+    console.print(f"  [green]Spec valid.[/green] Product: {domain_name}/{product_name}")
+
+    try:
+        session = _get_session_from_ctx(ctx)
+        dynamodb = session.resource("dynamodb")
+        products_table = dynamodb.Table(_PRODUCTS_TABLE)
+        product_id = f"{domain_name}#{product_name}"
+
+        # Duplicate guard
+        existing = products_table.get_item(Key={"product_id": product_id})
+        if existing.get("Item"):
+            console.print(
+                f"[red]Product '{domain_name}/{product_name}' is already registered in mesh-products.[/red]\n"
+                "Remove the existing entry or use a different product name."
+            )
+            raise typer.Exit(code=1)
+
+        # 2. Verify Glue database + table exist
+        console.print(f"\n[bold]Verifying Glue table:[/bold] {glue_database}.{glue_table}")
+        glue = session.client("glue")
+        try:
+            table_response = glue.get_table(DatabaseName=glue_database, Name=glue_table)
+            glue_table_obj = table_response["Table"]
+        except glue.exceptions.EntityNotFoundException:
+            console.print(
+                f"[red]Glue table not found:[/red] {glue_database}.{glue_table}\n"
+                "Verify the database and table names and that you have the correct AWS credentials."
+            )
+            raise typer.Exit(code=1)
+        except Exception as exc:
+            console.print(f"[red]Error looking up Glue table:[/red] {exc}")
+            raise typer.Exit(code=1) from exc
+
+        # 3. Verify Iceberg format
+        table_params = glue_table_obj.get("Parameters", {})
+        table_type = table_params.get("table_type", "").upper()
+        if table_type != "ICEBERG":
+            console.print(
+                f"[red]Table '{glue_database}.{glue_table}' is not an Iceberg table (table_type={table_type or 'unknown'}).[/red]\n"
+                "Only Iceberg-format tables can be imported as mesh products."
+            )
+            raise typer.Exit(code=1)
+        console.print(f"  [green]Iceberg table confirmed.[/green]")
+
+        # 4. Apply LF-Tags (best-effort)
+        if lf_grantor_role_arn:
+            try:
+                lf = session.client("lakeformation")
+                lf.add_lf_tags_to_resource(
+                    Resource={
+                        "Table": {
+                            "DatabaseName": glue_database,
+                            "Name": glue_table,
+                        }
+                    },
+                    LFTags=[
+                        {"TagKey": "classification", "TagValues": [classification]},
+                        {"TagKey": "pii", "TagValues": ["true" if has_pii else "false"]},
+                        {"TagKey": "domain", "TagValues": [domain_name]},
+                    ],
+                )
+                console.print("[green]LF-Tags applied.[/green]")
+            except Exception as exc:
+                console.print(f"[yellow]Warning: could not apply LF-Tags: {exc}[/yellow]")
+        else:
+            console.print("[dim]--lf-grantor-role-arn not set; skipping LF-Tag application.[/dim]")
+
+        # 5. Write catalog entry
+        now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        products_table.put_item(Item={
+            "product_id": product_id,
+            "domain": domain_name,
+            "product_name": product_name,
+            "owner": owner,
+            "description": description,
+            "status": "ACTIVE",
+            "import_source": "glue",
+            "glue_database": glue_database,
+            "glue_table": glue_table,
+            "schema_version": schema_version,
+            "classification": classification,
+            "pii": has_pii,
+            "imported_at": now_str,
+        })
+        console.print(f"[green]Catalog entry written to mesh-products.[/green] status=ACTIVE, import_source=glue")
+
+        # 6. Emit ProductCreated event
+        if event_bus_arn:
+            try:
+                from datameshy.lib.aws_client import put_mesh_event
+
+                put_mesh_event(
+                    session=session,
+                    event_bus_arn=event_bus_arn,
+                    event_type="ProductCreated",
+                    payload={
+                        "domain": domain_name,
+                        "product_name": product_name,
+                        "product_id": product_id,
+                        "owner": owner,
+                        "schema_version": schema_version,
+                        "import_source": "glue",
+                    },
+                )
+                console.print("[green]ProductCreated event emitted.[/green]")
+            except Exception as exc:
+                console.print(f"[yellow]Warning: could not emit ProductCreated event: {exc}[/yellow]")
+
+        console.print(
+            f"\n[bold green]Product '{domain_name}/{product_name}' imported successfully.[/bold green]\n"
+            f"  Glue source: {glue_database}.{glue_table}\n"
+            f"  Status: ACTIVE\n"
+            f"\nNext steps:\n"
+            f"  1. Check status: [cyan]datameshy product status --domain {domain_name} --name {product_name}[/cyan]\n"
+            f"  2. Search in catalog: [cyan]datameshy catalog search --keyword {product_name}[/cyan]"
+        )
+
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error importing product:[/red] {exc}")
         raise typer.Exit(code=1) from exc

--- a/cli/tests/test_product_deprecate.py
+++ b/cli/tests/test_product_deprecate.py
@@ -1,0 +1,261 @@
+"""Tests for CLI product deprecate command — Issue #13."""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+from typer.testing import CliRunner
+
+from datameshy.cli import app
+
+runner = CliRunner()
+
+
+def _invoke(*args, **kwargs):
+    return runner.invoke(app, *args, **kwargs)
+
+
+def _setup_mock_session(session):
+    from datameshy.lib import aws_client
+    return patch.object(aws_client, "get_session", return_value=session)
+
+
+def _make_tables(session, put_product=True, status="ACTIVE"):
+    dynamodb = session.resource("dynamodb")
+
+    products_table = dynamodb.create_table(
+        TableName="mesh-products",
+        KeySchema=[{"AttributeName": "product_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "product_id", "AttributeType": "S"},
+            {"AttributeName": "domain", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "domain-index",
+                "KeySchema": [{"AttributeName": "domain", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    )
+
+    dynamodb.create_table(
+        TableName="mesh-subscriptions",
+        KeySchema=[{"AttributeName": "subscription_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "subscription_id", "AttributeType": "S"},
+            {"AttributeName": "product_id", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "product-index",
+                "KeySchema": [{"AttributeName": "product_id", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    )
+
+    if put_product:
+        products_table.put_item(Item={
+            "product_id": "sales#customer_orders",
+            "domain": "sales",
+            "product_name": "customer_orders",
+            "owner": "sales@company.com",
+            "status": status,
+        })
+
+    return products_table
+
+
+class TestProductDeprecate:
+    """Tests for 'datameshy product deprecate' command."""
+
+    @mock_aws
+    def test_deprecate_active_product_marks_deprecated(self):
+        """deprecate on ACTIVE product sets status=DEPRECATED and sunset_date."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table = _make_tables(session)
+
+        with _setup_mock_session(session), \
+             patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-123"), \
+             patch("boto3.client") as mock_boto_client:
+            # Mock scheduler client
+            mock_sched = MagicMock()
+            mock_sched.create_schedule.return_value = {"ScheduleArn": "arn:aws:scheduler:us-east-1:123:schedule/retire-sales-customer_orders"}
+            mock_boto_client.return_value = mock_sched
+
+            result = _invoke([
+                "product", "deprecate",
+                "sales/customer_orders",
+                "--sunset-days", "90",
+                "--event-bus-arn", "arn:fake:bus",
+                "--retirement-lambda-arn", "arn:fake:lambda",
+            ])
+
+        assert result.exit_code == 0, result.output
+        assert "deprecated" in result.output.lower() or "DEPRECATED" in result.output
+
+        item = products_table.get_item(Key={"product_id": "sales#customer_orders"}).get("Item", {})
+        assert item["status"] == "DEPRECATED"
+        assert "sunset_date" in item
+        assert item.get("sunset_days") == 90
+
+    @mock_aws
+    def test_deprecate_already_deprecated_rejected(self):
+        """deprecate on DEPRECATED product returns a clear error."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session, status="DEPRECATED")
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "deprecate",
+                "sales/customer_orders",
+                "--sunset-days", "30",
+            ])
+
+        assert result.exit_code != 0
+        assert "already" in result.output.lower() or "deprecated" in result.output.lower()
+
+    @mock_aws
+    def test_deprecate_retired_product_rejected(self):
+        """deprecate on RETIRED product returns a clear error."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session, status="RETIRED")
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "deprecate",
+                "sales/customer_orders",
+                "--sunset-days", "30",
+            ])
+
+        assert result.exit_code != 0
+        assert "retired" in result.output.lower() or "cannot" in result.output.lower()
+
+    @mock_aws
+    def test_deprecate_nonexistent_product(self):
+        """deprecate on non-existent product returns clear error."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session, put_product=False)
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "deprecate",
+                "sales/nonexistent",
+                "--sunset-days", "30",
+            ])
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    @mock_aws
+    def test_deprecate_emits_product_deprecated_event(self):
+        """ProductDeprecated event emitted with breaking=true and sunset_date."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session)
+
+        with _setup_mock_session(session), \
+             patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-456") as mock_emit, \
+             patch("boto3.client") as mock_boto_client:
+            mock_boto_client.return_value = MagicMock()
+
+            result = _invoke([
+                "product", "deprecate",
+                "sales/customer_orders",
+                "--sunset-days", "60",
+                "--event-bus-arn", "arn:fake:bus",
+                "--retirement-lambda-arn", "arn:fake:lambda",
+            ])
+
+        assert result.exit_code == 0, result.output
+        mock_emit.assert_called_once()
+        call_kwargs = mock_emit.call_args
+        assert call_kwargs[1]["event_type"] == "ProductDeprecated"
+        payload = call_kwargs[1]["payload"]
+        assert payload.get("breaking") is True
+        assert "sunset_date" in payload
+
+    @mock_aws
+    def test_deprecate_creates_scheduler_rule(self):
+        """EventBridge Scheduler rule created targeting retirement Lambda at sunset_date."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session)
+
+        mock_sched = MagicMock()
+        mock_sched.create_schedule.return_value = {"ScheduleArn": "arn:aws:scheduler:us-east-1:123:schedule/retire-test"}
+
+        with _setup_mock_session(session), \
+             patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-789"), \
+             patch("boto3.client", return_value=mock_sched):
+            result = _invoke([
+                "product", "deprecate",
+                "sales/customer_orders",
+                "--sunset-days", "45",
+                "--event-bus-arn", "arn:fake:bus",
+                "--retirement-lambda-arn", "arn:fake:lambda",
+                "--scheduler-role-arn", "arn:fake:role",
+            ])
+
+        assert result.exit_code == 0, result.output
+        mock_sched.create_schedule.assert_called_once()
+
+    @mock_aws
+    def test_deprecate_status_shows_deprecated(self):
+        """product status shows status=deprecated and sunset_date after deprecation."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        # _make_tables creates mesh-subscriptions, so don't duplicate
+        products_table = _make_tables(session)
+
+        # Manually mark deprecated so we can test status display
+        products_table.update_item(
+            Key={"product_id": "sales#customer_orders"},
+            UpdateExpression="SET #s = :dep, sunset_date = :sd",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={":dep": "DEPRECATED", ":sd": "2026-08-01"},
+        )
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "status",
+                "--domain", "sales",
+                "--name", "customer_orders",
+            ])
+
+        assert result.exit_code == 0
+        assert "DEPRECATED" in result.output
+        assert "2026-08-01" in result.output

--- a/cli/tests/test_product_deprecate.py
+++ b/cli/tests/test_product_deprecate.py
@@ -25,7 +25,12 @@ def _setup_mock_session(session):
     return patch.object(aws_client, "get_session", return_value=session)
 
 
-def _make_tables(session, put_product=True, status="ACTIVE"):
+OWNER_ARN = "arn:aws:iam::123456789012:user/sales-owner"
+NON_OWNER_ARN = "arn:aws:iam::123456789012:user/some-other-user"
+ADMIN_ARN = "arn:aws:iam::123456789012:role/MeshAdminRole"
+
+
+def _make_tables(session, put_product=True, status="ACTIVE", owner=OWNER_ARN):
     dynamodb = session.resource("dynamodb")
 
     products_table = dynamodb.create_table(
@@ -67,7 +72,7 @@ def _make_tables(session, put_product=True, status="ACTIVE"):
             "product_id": "sales#customer_orders",
             "domain": "sales",
             "product_name": "customer_orders",
-            "owner": "sales@company.com",
+            "owner": owner,
             "status": status,
         })
 
@@ -87,14 +92,22 @@ class TestProductDeprecate:
         session = boto3.Session(region_name="us-east-1")
         products_table = _make_tables(session)
 
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Arn": OWNER_ARN}
+                return mock_sts
+            if service == "scheduler":
+                mock_sched = MagicMock()
+                mock_sched.create_schedule.return_value = {"ScheduleArn": "arn:aws:scheduler:us-east-1:123:schedule/retire"}
+                return mock_sched
+            return real_client(service, **kwargs)
+
         with _setup_mock_session(session), \
              patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-123"), \
-             patch("boto3.client") as mock_boto_client:
-            # Mock scheduler client
-            mock_sched = MagicMock()
-            mock_sched.create_schedule.return_value = {"ScheduleArn": "arn:aws:scheduler:us-east-1:123:schedule/retire-sales-customer_orders"}
-            mock_boto_client.return_value = mock_sched
-
+             patch.object(session, "client", side_effect=patched_client):
             result = _invoke([
                 "product", "deprecate",
                 "sales/customer_orders",
@@ -181,11 +194,20 @@ class TestProductDeprecate:
         session = boto3.Session(region_name="us-east-1")
         _make_tables(session)
 
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Arn": OWNER_ARN}
+                return mock_sts
+            if service == "scheduler":
+                return MagicMock()
+            return real_client(service, **kwargs)
+
         with _setup_mock_session(session), \
              patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-456") as mock_emit, \
-             patch("boto3.client") as mock_boto_client:
-            mock_boto_client.return_value = MagicMock()
-
+             patch.object(session, "client", side_effect=patched_client):
             result = _invoke([
                 "product", "deprecate",
                 "sales/customer_orders",
@@ -215,9 +237,22 @@ class TestProductDeprecate:
         mock_sched = MagicMock()
         mock_sched.create_schedule.return_value = {"ScheduleArn": "arn:aws:scheduler:us-east-1:123:schedule/retire-test"}
 
+        real_client = session.client
+
+        def patched_session_client(service, **kwargs):
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Arn": OWNER_ARN}
+                return mock_sts
+            return real_client(service, **kwargs)
+
+        # The scheduler is created via `boto3.client("scheduler", ...)` inside
+        # the command's local import; patch boto3.client globally
         with _setup_mock_session(session), \
              patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-789"), \
+             patch.object(session, "client", side_effect=patched_session_client), \
              patch("boto3.client", return_value=mock_sched):
+
             result = _invoke([
                 "product", "deprecate",
                 "sales/customer_orders",
@@ -259,3 +294,70 @@ class TestProductDeprecate:
         assert result.exit_code == 0
         assert "DEPRECATED" in result.output
         assert "2026-08-01" in result.output
+
+    @mock_aws
+    def test_deprecate_rejects_non_owner(self):
+        """deprecate fails with authorization error when caller is not the product owner."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session, owner=OWNER_ARN)
+
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "sts":
+                mock_sts = MagicMock()
+                # Caller is NOT the owner
+                mock_sts.get_caller_identity.return_value = {"Arn": NON_OWNER_ARN}
+                return mock_sts
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "deprecate",
+                "sales/customer_orders",
+                "--sunset-days", "90",
+            ])
+
+        assert result.exit_code != 0
+        assert "authorization failed" in result.output.lower() or "not the owner" in result.output.lower()
+
+    @mock_aws
+    def test_deprecate_allows_mesh_admin(self):
+        """deprecate succeeds when caller has MeshAdminRole even if not the owner."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table = _make_tables(session, owner=OWNER_ARN)
+
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "sts":
+                mock_sts = MagicMock()
+                # Caller has MeshAdminRole
+                mock_sts.get_caller_identity.return_value = {"Arn": ADMIN_ARN}
+                return mock_sts
+            if service == "scheduler":
+                return MagicMock()
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-admin"), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "deprecate",
+                "sales/customer_orders",
+                "--sunset-days", "30",
+                "--event-bus-arn", "arn:fake:bus",
+            ])
+
+        assert result.exit_code == 0, result.output
+        item = products_table.get_item(Key={"product_id": "sales#customer_orders"}).get("Item", {})
+        assert item["status"] == "DEPRECATED"

--- a/cli/tests/test_product_import.py
+++ b/cli/tests/test_product_import.py
@@ -1,0 +1,346 @@
+"""Tests for CLI product import command — Issue #15."""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+from typer.testing import CliRunner
+
+from datameshy.cli import app
+
+runner = CliRunner()
+
+SAMPLE_PRODUCT_YAML = textwrap.dedent("""\
+    product:
+      name: revenue_daily
+      domain: sales
+      description: "Daily revenue aggregated by region"
+      owner: sales-data@company.com
+
+    schema_version: 1
+
+    schema:
+      format: iceberg
+      columns:
+        - name: date
+          type: date
+          pii: false
+          nullable: false
+        - name: region
+          type: string
+          pii: false
+          nullable: false
+        - name: revenue
+          type: decimal(14,2)
+          pii: false
+          nullable: false
+
+    quality:
+      rules:
+        - name: date_complete
+          rule: "IsComplete 'date'"
+
+    sla:
+      refresh_frequency: daily
+
+    classification: internal
+""")
+
+INVALID_PRODUCT_YAML = textwrap.dedent("""\
+    product:
+      name: bad_product
+    # Missing required fields
+""")
+
+
+def _invoke(*args, **kwargs):
+    return runner.invoke(app, *args, **kwargs)
+
+
+def _setup_mock_session(session):
+    from datameshy.lib import aws_client
+    return patch.object(aws_client, "get_session", return_value=session)
+
+
+def _make_products_table(session):
+    dynamodb = session.resource("dynamodb")
+    table = dynamodb.create_table(
+        TableName="mesh-products",
+        KeySchema=[{"AttributeName": "product_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "product_id", "AttributeType": "S"},
+            {"AttributeName": "domain", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[{
+            "IndexName": "domain-index",
+            "KeySchema": [{"AttributeName": "domain", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "ALL"},
+        }],
+    )
+    return table
+
+
+@pytest.fixture
+def spec_file(tmp_path):
+    p = tmp_path / "product.yaml"
+    p.write_text(SAMPLE_PRODUCT_YAML, encoding="utf-8")
+    return str(p)
+
+
+@pytest.fixture
+def invalid_spec_file(tmp_path):
+    p = tmp_path / "product.yaml"
+    p.write_text(INVALID_PRODUCT_YAML, encoding="utf-8")
+    return str(p)
+
+
+class _FakeEntityNotFound(Exception):
+    """Stand-in for botocore EntityNotFoundException."""
+
+
+def _make_glue_mock(iceberg=True, exists=True):
+    """Return a mock Glue client that returns an Iceberg table."""
+    mock_glue = MagicMock()
+    # Wire exceptions so isinstance checks work
+    mock_glue.exceptions.EntityNotFoundException = _FakeEntityNotFound
+    if not exists:
+        mock_glue.get_table.side_effect = _FakeEntityNotFound("Table not found")
+    else:
+        mock_glue.get_table.return_value = {
+            "Table": {
+                "Name": "revenue_daily",
+                "DatabaseName": "sales_domain",
+                "Parameters": {"table_type": "ICEBERG" if iceberg else "HIVE"},
+                "StorageDescriptor": {
+                    "Location": "s3://sales-gold-123/revenue_daily",
+                    "Columns": [],
+                },
+            }
+        }
+    return mock_glue
+
+
+class TestProductImport:
+    """Tests for 'datameshy product import' command."""
+
+    @mock_aws
+    def test_import_registers_product_as_active(self, spec_file):
+        """Successful import writes ACTIVE entry with import_source=glue."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table = _make_products_table(session)
+
+        mock_glue = _make_glue_mock()
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "glue":
+                return mock_glue
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "import",
+                "--spec", spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "revenue_daily",
+            ])
+
+        assert result.exit_code == 0, result.output
+        item = products_table.get_item(Key={"product_id": "sales#revenue_daily"}).get("Item", {})
+        assert item["status"] == "ACTIVE"
+        assert item["import_source"] == "glue"
+
+    @mock_aws
+    def test_import_validates_spec_before_proceeding(self, invalid_spec_file):
+        """Invalid spec fails before any Glue calls."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_products_table(session)
+
+        mock_glue = _make_glue_mock()
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "import",
+                "--spec", invalid_spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "revenue_daily",
+            ])
+
+        assert result.exit_code != 0
+        mock_glue.get_table.assert_not_called()
+
+    @mock_aws
+    def test_import_fails_if_glue_table_not_found(self, spec_file):
+        """Clear error if Glue table doesn't exist."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_products_table(session)
+
+        mock_glue = _make_glue_mock(exists=False)
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "glue":
+                return mock_glue
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "import",
+                "--spec", spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "nonexistent",
+            ])
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower() or "error" in result.output.lower()
+
+    @mock_aws
+    def test_import_fails_if_table_not_iceberg(self, spec_file):
+        """Clear error if Glue table is not Iceberg format."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_products_table(session)
+
+        mock_glue = _make_glue_mock(iceberg=False)
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "glue":
+                return mock_glue
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "import",
+                "--spec", spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "revenue_daily",
+            ])
+
+        assert result.exit_code != 0
+        assert "iceberg" in result.output.lower()
+
+    @mock_aws
+    def test_import_duplicate_guard(self, spec_file):
+        """Returns clear error if product already registered."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table = _make_products_table(session)
+        products_table.put_item(Item={
+            "product_id": "sales#revenue_daily",
+            "domain": "sales",
+            "product_name": "revenue_daily",
+            "status": "ACTIVE",
+        })
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "import",
+                "--spec", spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "revenue_daily",
+            ])
+
+        assert result.exit_code != 0
+        assert "already" in result.output.lower() or "duplicate" in result.output.lower()
+
+    @mock_aws
+    def test_import_emits_product_created_event(self, spec_file):
+        """ProductCreated event emitted after successful import."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_products_table(session)
+
+        mock_glue = _make_glue_mock()
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "glue":
+                return mock_glue
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client), \
+             patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-import") as mock_emit:
+            result = _invoke([
+                "product", "import",
+                "--spec", spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "revenue_daily",
+                "--event-bus-arn", "arn:fake:bus",
+            ])
+
+        assert result.exit_code == 0, result.output
+        mock_emit.assert_called_once()
+        call_kwargs = mock_emit.call_args
+        assert call_kwargs[1]["event_type"] == "ProductCreated"
+        payload = call_kwargs[1]["payload"]
+        assert payload.get("import_source") == "glue"
+
+    @mock_aws
+    def test_import_catalog_entry_discoverable(self, spec_file):
+        """Imported product entry has all expected catalog fields."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table = _make_products_table(session)
+
+        mock_glue = _make_glue_mock()
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "glue":
+                return mock_glue
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "import",
+                "--spec", spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "revenue_daily",
+            ])
+
+        assert result.exit_code == 0, result.output
+        item = products_table.get_item(Key={"product_id": "sales#revenue_daily"}).get("Item", {})
+        assert item["domain"] == "sales"
+        assert item["product_name"] == "revenue_daily"
+        assert item["glue_database"] == "sales_domain"
+        assert item["glue_table"] == "revenue_daily"
+        assert "imported_at" in item
+        assert item["status"] == "ACTIVE"
+        assert item["import_source"] == "glue"

--- a/cli/tests/test_product_import.py
+++ b/cli/tests/test_product_import.py
@@ -106,7 +106,12 @@ class _FakeEntityNotFound(Exception):
     """Stand-in for botocore EntityNotFoundException."""
 
 
-def _make_glue_mock(iceberg=True, exists=True):
+MOCK_ACCOUNT_ID = "123456789012"
+VALID_LOCATION = f"s3://sales-gold-{MOCK_ACCOUNT_ID}/revenue_daily"
+INVALID_LOCATION = "s3://other-bucket-999999999999/revenue_daily"
+
+
+def _make_glue_mock(iceberg=True, exists=True, location=VALID_LOCATION):
     """Return a mock Glue client that returns an Iceberg table."""
     mock_glue = MagicMock()
     # Wire exceptions so isinstance checks work
@@ -120,7 +125,7 @@ def _make_glue_mock(iceberg=True, exists=True):
                 "DatabaseName": "sales_domain",
                 "Parameters": {"table_type": "ICEBERG" if iceberg else "HIVE"},
                 "StorageDescriptor": {
-                    "Location": "s3://sales-gold-123/revenue_daily",
+                    "Location": location,
                     "Columns": [],
                 },
             }
@@ -147,6 +152,10 @@ class TestProductImport:
         def patched_client(service, **kwargs):
             if service == "glue":
                 return mock_glue
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Account": MOCK_ACCOUNT_ID}
+                return mock_sts
             return real_client(service, **kwargs)
 
         with _setup_mock_session(session), \
@@ -231,6 +240,10 @@ class TestProductImport:
         def patched_client(service, **kwargs):
             if service == "glue":
                 return mock_glue
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Account": MOCK_ACCOUNT_ID}
+                return mock_sts
             return real_client(service, **kwargs)
 
         with _setup_mock_session(session), \
@@ -288,6 +301,10 @@ class TestProductImport:
         def patched_client(service, **kwargs):
             if service == "glue":
                 return mock_glue
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Account": MOCK_ACCOUNT_ID}
+                return mock_sts
             return real_client(service, **kwargs)
 
         with _setup_mock_session(session), \
@@ -324,6 +341,10 @@ class TestProductImport:
         def patched_client(service, **kwargs):
             if service == "glue":
                 return mock_glue
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Account": MOCK_ACCOUNT_ID}
+                return mock_sts
             return real_client(service, **kwargs)
 
         with _setup_mock_session(session), \
@@ -344,3 +365,38 @@ class TestProductImport:
         assert "imported_at" in item
         assert item["status"] == "ACTIVE"
         assert item["import_source"] == "glue"
+
+    @mock_aws
+    def test_import_rejects_wrong_s3_prefix(self, spec_file):
+        """import rejects table whose S3 location does not match the domain's gold bucket."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_products_table(session)
+
+        # Table in a different/wrong bucket
+        mock_glue = _make_glue_mock(location=INVALID_LOCATION)
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "glue":
+                return mock_glue
+            if service == "sts":
+                mock_sts = MagicMock()
+                mock_sts.get_caller_identity.return_value = {"Account": MOCK_ACCOUNT_ID}
+                return mock_sts
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "import",
+                "--spec", spec_file,
+                "--glue-database", "sales_domain",
+                "--glue-table", "revenue_daily",
+            ])
+
+        assert result.exit_code != 0
+        assert "gold bucket" in result.output.lower() or "location" in result.output.lower()

--- a/cli/tests/test_product_rollback.py
+++ b/cli/tests/test_product_rollback.py
@@ -1,0 +1,285 @@
+"""Tests for CLI product rollback command — Issue #14."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+from typer.testing import CliRunner
+
+from datameshy.cli import app
+
+runner = CliRunner()
+
+
+def _invoke(*args, **kwargs):
+    return runner.invoke(app, *args, **kwargs)
+
+
+def _setup_mock_session(session):
+    from datameshy.lib import aws_client
+    return patch.object(aws_client, "get_session", return_value=session)
+
+
+def _make_tables(session, product_status="ACTIVE"):
+    dynamodb = session.resource("dynamodb")
+
+    products_table = dynamodb.create_table(
+        TableName="mesh-products",
+        KeySchema=[{"AttributeName": "product_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "product_id", "AttributeType": "S"},
+            {"AttributeName": "domain", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[{
+            "IndexName": "domain-index",
+            "KeySchema": [{"AttributeName": "domain", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "ALL"},
+        }],
+    )
+
+    locks_table = dynamodb.create_table(
+        TableName="mesh-pipeline-locks",
+        KeySchema=[{"AttributeName": "product_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "product_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    products_table.put_item(Item={
+        "product_id": "sales#customer_orders",
+        "domain": "sales",
+        "product_name": "customer_orders",
+        "owner": "sales@company.com",
+        "status": product_status,
+        "glue_catalog_db_gold": "sales_gold",
+    })
+
+    return products_table, locks_table
+
+
+class TestProductRollback:
+    """Tests for 'datameshy product rollback' command."""
+
+    @mock_aws
+    def test_rollback_requires_flag(self):
+        """rollback without --to-snapshot or --list-snapshots exits with error."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session)
+
+        with _setup_mock_session(session):
+            result = _invoke(["product", "rollback", "sales/customer_orders"])
+
+        assert result.exit_code != 0
+
+    @mock_aws
+    def test_list_snapshots_shows_athena_query(self):
+        """--list-snapshots prints the Athena query hint."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session)
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--list-snapshots",
+            ])
+
+        assert result.exit_code == 0
+        assert "snapshot" in result.output.lower()
+        # Should show helpful SQL / guidance
+        assert "SELECT" in result.output or "snapshots" in result.output
+
+    @mock_aws
+    def test_rollback_to_snapshot_acquires_and_releases_lock(self):
+        """--to-snapshot acquires pipeline lock, runs rollback, releases lock."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table, locks_table = _make_tables(session)
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--to-snapshot", "8765309",
+            ])
+
+        assert result.exit_code == 0, result.output
+        # Lock must be released after rollback
+        lock = locks_table.get_item(Key={"product_id": "sales#customer_orders"}).get("Item")
+        assert lock is None
+
+    @mock_aws
+    def test_rollback_blocked_when_pipeline_locked(self):
+        """rollback blocked if pipeline lock is active."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table, locks_table = _make_tables(session)
+
+        locks_table.put_item(Item={"product_id": "sales#customer_orders", "locked": True})
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--to-snapshot", "1234",
+            ])
+
+        assert result.exit_code != 0
+        assert "lock" in result.output.lower() or "running" in result.output.lower()
+
+    @mock_aws
+    def test_rollback_updates_catalog_metadata(self):
+        """After rollback, last_refreshed updated in mesh-products."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        products_table, locks_table = _make_tables(session)
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--to-snapshot", "9876543",
+            ])
+
+        assert result.exit_code == 0, result.output
+        item = products_table.get_item(Key={"product_id": "sales#customer_orders"}).get("Item", {})
+        assert "last_refreshed" in item
+        assert item.get("last_rollback_snapshot") == 9876543
+
+    @mock_aws
+    def test_rollback_blocked_for_deprecated_product(self):
+        """rollback blocked if product status is DEPRECATED."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session, product_status="DEPRECATED")
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--to-snapshot", "111",
+            ])
+
+        assert result.exit_code != 0
+        assert "deprecated" in result.output.lower() or "blocked" in result.output.lower()
+
+    @mock_aws
+    def test_rollback_blocked_for_retired_product(self):
+        """rollback blocked if product status is RETIRED."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session, product_status="RETIRED")
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--to-snapshot", "222",
+            ])
+
+        assert result.exit_code != 0
+        assert "retired" in result.output.lower() or "blocked" in result.output.lower()
+
+    @mock_aws
+    def test_rollback_emits_product_refreshed_event(self):
+        """ProductRefreshed event emitted after rollback."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session)
+
+        with _setup_mock_session(session), \
+             patch("datameshy.lib.aws_client.put_mesh_event", return_value="evt-rollback") as mock_emit:
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--to-snapshot", "555",
+                "--event-bus-arn", "arn:fake:bus",
+            ])
+
+        assert result.exit_code == 0, result.output
+        mock_emit.assert_called_once()
+        call_kwargs = mock_emit.call_args
+        assert call_kwargs[1]["event_type"] == "ProductRefreshed"
+
+    @mock_aws
+    def test_rollback_with_glue_job(self):
+        """--glue-job-name triggers a Glue job run."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session)
+
+        mock_glue = MagicMock()
+        mock_glue.start_job_run.return_value = {"JobRunId": "jr-abc123"}
+
+        # Patch only the glue client call in product.py, keeping other session calls intact
+        real_client = session.client
+
+        def patched_client(service, **kwargs):
+            if service == "glue":
+                return mock_glue
+            return real_client(service, **kwargs)
+
+        with _setup_mock_session(session), \
+             patch.object(session, "client", side_effect=patched_client):
+            result = _invoke([
+                "product", "rollback",
+                "sales/customer_orders",
+                "--to-snapshot", "777",
+                "--glue-job-name", "mesh-iceberg-rollback",
+            ])
+
+        assert result.exit_code == 0, result.output
+        mock_glue.start_job_run.assert_called_once()
+
+    @mock_aws
+    def test_rollback_product_not_found(self):
+        """rollback on non-existent product returns clear error."""
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+        session = boto3.Session(region_name="us-east-1")
+        _make_tables(session)
+
+        with _setup_mock_session(session):
+            result = _invoke([
+                "product", "rollback",
+                "sales/nonexistent",
+                "--to-snapshot", "999",
+            ])
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()

--- a/infra/modules/data-product/lifecycle.tf
+++ b/infra/modules/data-product/lifecycle.tf
@@ -1,0 +1,226 @@
+##############################################################################
+# data-product/lifecycle.tf
+#
+# Product lifecycle infrastructure — Phase 3, Stream 2
+#
+# Creates:
+#   - EventBridge rule matching ProductDeprecated events → product_deprecation Lambda
+#   - IAM role for EventBridge Scheduler to invoke the retirement Lambda
+#   - IAM role for the retirement Lambda
+#   - (Optional) Glue job for Iceberg rollback
+#
+# Note: The one-shot EventBridge Scheduler rule targeting the retirement Lambda
+# at sunset_date is created DYNAMICALLY by the CLI (`datameshy product deprecate`)
+# via Boto3, not statically here — because each product has a different sunset_date.
+# This file provisions only the IAM roles/policies needed for that dynamic pattern.
+##############################################################################
+
+# ── EventBridge rule: ProductDeprecated → deprecation Lambda ──────────────────
+
+resource "aws_cloudwatch_event_rule" "product_deprecated" {
+  name           = "${var.domain}-${var.product_name}-product-deprecated"
+  description    = "Trigger deprecation Lambda when ProductDeprecated event fires for ${var.domain}/${var.product_name}."
+  event_bus_name = var.domain_event_bus_arn
+
+  event_pattern = jsonencode({
+    detail-type = ["ProductDeprecated"]
+    detail = {
+      product_id = ["${local.product_id}"]
+    }
+  })
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "product_deprecated_lambda" {
+  count     = var.product_deprecation_lambda_arn != "" ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.product_deprecated.name
+  target_id = "ProductDeprecationHandler"
+  arn       = var.product_deprecation_lambda_arn
+
+  event_bus_name = var.domain_event_bus_arn
+}
+
+resource "aws_lambda_permission" "allow_events_deprecation" {
+  count         = var.product_deprecation_lambda_arn != "" ? 1 : 0
+  statement_id  = "AllowEventBridgeDeprecation-${var.domain}-${var.product_name}"
+  action        = "lambda:InvokeFunction"
+  function_name = var.product_deprecation_lambda_arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.product_deprecated.arn
+}
+
+# ── IAM role for EventBridge Scheduler → retirement Lambda ───────────────────
+# The one-shot schedule is created dynamically by the CLI; this role is the
+# static execution role referenced in the dynamic create_schedule call.
+
+resource "aws_iam_role" "scheduler_retirement" {
+  name        = "${var.domain}-${var.product_name}-scheduler-retirement"
+  description = "Allows EventBridge Scheduler to invoke the retirement Lambda for ${var.domain}/${var.product_name}."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "scheduler.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = local.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "scheduler_retirement_invoke" {
+  name = "InvokeRetirementLambda"
+  role = aws_iam_role.scheduler_retirement.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = var.retirement_lambda_arn != "" ? [var.retirement_lambda_arn] : ["arn:aws:lambda:${local.region}:${local.account_id}:function:*-retirement"]
+      }
+    ]
+  })
+}
+
+# ── IAM role for retirement Lambda execution ──────────────────────────────────
+
+resource "aws_iam_role" "retirement_lambda" {
+  name        = "${var.domain}-retirement-lambda"
+  description = "Execution role for the retirement Lambda — revokes LF grants, marks product RETIRED."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "retirement_lambda_permissions" {
+  name = "RetirementLambdaPermissions"
+  role = aws_iam_role.retirement_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBAccess"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:Query",
+          "dynamodb:Scan"
+        ]
+        Resource = [
+          "arn:aws:dynamodb:${local.region}:${local.account_id}:table/${var.mesh_products_table_name}",
+          "arn:aws:dynamodb:${local.region}:${local.account_id}:table/${var.mesh_subscriptions_table_name}",
+          "arn:aws:dynamodb:${local.region}:${local.account_id}:table/${var.mesh_audit_log_table_name}",
+          "arn:aws:dynamodb:${local.region}:${local.account_id}:table/${var.mesh_subscriptions_table_name}/index/*"
+        ]
+      },
+      {
+        Sid    = "LakeFormationRevoke"
+        Effect = "Allow"
+        Action = [
+          "lakeformation:BatchRevokePermissions",
+          "lakeformation:RevokePermissions",
+          "lakeformation:ListPermissions"
+        ]
+        Resource = ["*"]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [
+          "arn:aws:events:${local.region}:${local.account_id}:event-bus/*"
+        ]
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/*"]
+      }
+    ]
+  })
+}
+
+# ── Glue job for Iceberg rollback ─────────────────────────────────────────────
+# Optional: only created when var.rollback_glue_script_s3_path is set.
+
+resource "aws_glue_job" "iceberg_rollback" {
+  count    = var.rollback_glue_script_s3_path != "" ? 1 : 0
+  name     = "${var.domain}-${var.product_name}-iceberg-rollback"
+  role_arn = var.glue_job_execution_role_arn
+
+  description = "Restores the ${var.domain}/${var.product_name} gold Iceberg table to a prior snapshot."
+
+  glue_version      = "4.0"
+  number_of_workers = 2
+  worker_type       = "G.1X"
+
+  command {
+    name            = "glueetl"
+    script_location = var.rollback_glue_script_s3_path
+    python_version  = "3"
+  }
+
+  default_arguments = {
+    "--job-language"                     = "python"
+    "--enable-continuous-cloudwatch-log" = "true"
+    "--enable-metrics"                   = "true"
+    "--enable-glue-datacatalog"          = "true"
+    "--domain"                           = var.domain
+    "--product_name"                     = var.product_name
+    "--gold_db"                          = var.glue_catalog_db_gold
+    "--table_name"                       = var.product_name
+    "--products_table_name"              = var.mesh_products_table_name
+    "--pipeline_locks_table_name"        = var.mesh_pipeline_locks_table_name
+    "--central_event_bus_arn"            = var.central_event_bus_arn
+    # --snapshot_id is passed at runtime by the CLI
+    "--datalake-formats" = "iceberg"
+    "--conf"             = "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
+  }
+
+  tags = local.tags
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "scheduler_retirement_role_arn" {
+  description = "IAM role ARN for EventBridge Scheduler to invoke the retirement Lambda."
+  value       = aws_iam_role.scheduler_retirement.arn
+}
+
+output "retirement_lambda_role_arn" {
+  description = "IAM role ARN for the retirement Lambda execution."
+  value       = aws_iam_role.retirement_lambda.arn
+}
+
+output "rollback_glue_job_name" {
+  description = "Name of the Glue Iceberg rollback job (empty string if not created)."
+  value       = var.rollback_glue_script_s3_path != "" ? aws_glue_job.iceberg_rollback[0].name : ""
+}

--- a/infra/modules/data-product/lifecycle.tf
+++ b/infra/modules/data-product/lifecycle.tf
@@ -87,10 +87,23 @@ resource "aws_iam_role_policy" "scheduler_retirement_invoke" {
       {
         Effect   = "Allow"
         Action   = ["lambda:InvokeFunction"]
-        Resource = var.retirement_lambda_arn != "" ? [var.retirement_lambda_arn] : ["arn:aws:lambda:${local.region}:${local.account_id}:function:*-retirement"]
+        Resource = [var.retirement_lambda_arn]
       }
     ]
   })
+}
+
+# ── Lambda permission: restrict retirement Lambda invocation to Scheduler ──────
+# CRITICAL 1: Prevents unauthorized invocation of the retirement Lambda which
+# performs mass LF grant revocations. Only the specific scheduler group may invoke.
+
+resource "aws_lambda_permission" "retirement_scheduler" {
+  count         = var.retirement_lambda_arn != "" ? 1 : 0
+  statement_id  = "AllowSchedulerInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.retirement_lambda_arn
+  principal     = "scheduler.amazonaws.com"
+  source_arn    = "arn:aws:scheduler:${local.region}:${local.account_id}:schedule/mesh-retirement/*"
 }
 
 # ── IAM role for retirement Lambda execution ──────────────────────────────────

--- a/infra/modules/data-product/variables.tf
+++ b/infra/modules/data-product/variables.tf
@@ -206,9 +206,8 @@ variable "product_deprecation_lambda_arn" {
 }
 
 variable "retirement_lambda_arn" {
-  description = "ARN of the retirement Lambda (triggered by EventBridge Scheduler at sunset_date). Leave empty for wildcard policy."
+  description = "ARN of the retirement Lambda (triggered by EventBridge Scheduler at sunset_date). Required — Terraform plan fails if not set, preventing wildcard Lambda permissions."
   type        = string
-  default     = ""
 }
 
 variable "rollback_glue_script_s3_path" {

--- a/infra/modules/data-product/variables.tf
+++ b/infra/modules/data-product/variables.tf
@@ -196,3 +196,29 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+# ── Lifecycle variables (Phase 3 Stream 2) ────────────────────────────────────
+
+variable "product_deprecation_lambda_arn" {
+  description = "ARN of the product_deprecation Lambda (handles ProductDeprecated events). Leave empty to skip EventBridge target."
+  type        = string
+  default     = ""
+}
+
+variable "retirement_lambda_arn" {
+  description = "ARN of the retirement Lambda (triggered by EventBridge Scheduler at sunset_date). Leave empty for wildcard policy."
+  type        = string
+  default     = ""
+}
+
+variable "rollback_glue_script_s3_path" {
+  description = "S3 path to the iceberg_rollback.py Glue script. Leave empty to skip Glue job creation."
+  type        = string
+  default     = ""
+}
+
+variable "mesh_subscriptions_table_name" {
+  description = "DynamoDB table name for mesh-subscriptions (from governance module output)."
+  type        = string
+  default     = "mesh-subscriptions"
+}

--- a/lambdas/product_deprecation.py
+++ b/lambdas/product_deprecation.py
@@ -14,6 +14,7 @@ Runtime: Python 3.12
 import json
 import logging
 import os
+import re
 import time
 from typing import Any
 
@@ -62,11 +63,20 @@ def _notify_subscriber(
     sunset_date: str,
     domain: str,
     product_name: str,
-) -> None:
+) -> bool:
     """
     Send SNS notification to the subscriber's domain notification topic.
     Constructs the cross-account SNS topic ARN from the subscriber account ID.
+    Returns True on success, False on failure (so caller can track accurate count).
     """
+    # HIGH 4: Validate subscriber_account_id before constructing SNS ARN
+    if not re.fullmatch(r'\d{12}', subscriber_account_id):
+        logger.warning(
+            "Skipping subscriber with invalid account_id format",
+            extra={"account_id": subscriber_account_id},
+        )
+        return False
+
     topic_arn = (
         f"arn:aws:sns:{AWS_REGION}:{subscriber_account_id}:{SUBSCRIBER_SNS_TOPIC_NAME}"
     )
@@ -96,6 +106,7 @@ def _notify_subscriber(
             "SNS notification sent",
             extra={"subscriber_account": subscriber_account_id, "topic": topic_arn},
         )
+        return True
     except ClientError as exc:
         logger.warning(
             "Failed to send SNS notification",
@@ -105,6 +116,7 @@ def _notify_subscriber(
                 "error": str(exc),
             },
         )
+        return False
 
 
 def _write_audit(product_id: str, sunset_date: str, notified_count: int) -> None:
@@ -158,19 +170,20 @@ def handle_product_deprecated(event: dict, context: Any) -> dict:
     subscribers = _get_active_subscribers(product_id)
     notified = 0
 
-    # 2. Notify each subscriber
+    # 2. Notify each subscriber (MEDIUM 4: only count on successful send)
     for sub in subscribers:
         subscriber_account_id = sub.get("subscriber_account_id", "")
         if not subscriber_account_id:
             continue
-        _notify_subscriber(
+        sent = _notify_subscriber(
             subscriber_account_id=subscriber_account_id,
             product_id=product_id,
             sunset_date=sunset_date,
             domain=domain,
             product_name=product_name,
         )
-        notified += 1
+        if sent:
+            notified += 1
 
     logger.info(
         "Deprecation notifications sent",

--- a/lambdas/product_deprecation.py
+++ b/lambdas/product_deprecation.py
@@ -1,0 +1,192 @@
+"""
+product_deprecation.py — Handles ProductDeprecated events for Data Meshy.
+
+Triggered by: EventBridge rule matching detail-type == "ProductDeprecated"
+
+Responsibilities:
+  1. Read all ACTIVE subscriber accounts from mesh-subscriptions for the product
+  2. Send an SNS notification to each subscriber's topic with the sunset date
+  3. Write an audit entry via MeshAuditWriterRole
+
+Runtime: Python 3.12
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# ── Environment variable defaults ─────────────────────────────────────────────
+SUBSCRIPTIONS_TABLE = os.environ.get("MESH_SUBSCRIPTIONS_TABLE", "mesh-subscriptions")
+PRODUCTS_TABLE = os.environ.get("MESH_PRODUCTS_TABLE", "mesh-products")
+AUDIT_TABLE = os.environ.get("MESH_AUDIT_TABLE", "mesh-audit-log")
+# SNS topic name pattern in subscriber accounts (e.g. "datameshy-domain-notifications")
+SUBSCRIBER_SNS_TOPIC_NAME = os.environ.get(
+    "SUBSCRIBER_SNS_TOPIC_NAME", "datameshy-domain-notifications"
+)
+AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _get_dynamodb():
+    return boto3.resource("dynamodb")
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _get_active_subscribers(product_id: str) -> list[dict]:
+    """Return all ACTIVE subscription records for the product."""
+    ddb = _get_dynamodb()
+    table = ddb.Table(SUBSCRIPTIONS_TABLE)
+    response = table.query(
+        IndexName="product-index",
+        KeyConditionExpression=boto3.dynamodb.conditions.Key("product_id").eq(product_id),
+        FilterExpression=boto3.dynamodb.conditions.Attr("status").eq("ACTIVE"),
+    )
+    return response.get("Items", [])
+
+
+def _notify_subscriber(
+    subscriber_account_id: str,
+    product_id: str,
+    sunset_date: str,
+    domain: str,
+    product_name: str,
+) -> None:
+    """
+    Send SNS notification to the subscriber's domain notification topic.
+    Constructs the cross-account SNS topic ARN from the subscriber account ID.
+    """
+    topic_arn = (
+        f"arn:aws:sns:{AWS_REGION}:{subscriber_account_id}:{SUBSCRIBER_SNS_TOPIC_NAME}"
+    )
+    sns = boto3.client("sns")
+    subject = f"[DataMeshy] Data product '{domain}/{product_name}' will be retired on {sunset_date}"
+    message = (
+        f"NOTICE: The data product '{domain}/{product_name}' (ID: {product_id}) "
+        f"has been marked DEPRECATED and will be retired on {sunset_date}.\n\n"
+        "Action required:\n"
+        "  - Update your pipelines to stop consuming this product before the sunset date.\n"
+        "  - Contact the data product owner to discuss alternatives.\n"
+        "  - No new subscriptions will be accepted for this product.\n\n"
+        f"Sunset date: {sunset_date}\n"
+        f"Product ID: {product_id}"
+    )
+    try:
+        sns.publish(
+            TopicArn=topic_arn,
+            Subject=subject,
+            Message=message,
+            MessageAttributes={
+                "event_type": {"DataType": "String", "StringValue": "ProductDeprecated"},
+                "product_id": {"DataType": "String", "StringValue": product_id},
+            },
+        )
+        logger.info(
+            "SNS notification sent",
+            extra={"subscriber_account": subscriber_account_id, "topic": topic_arn},
+        )
+    except ClientError as exc:
+        logger.warning(
+            "Failed to send SNS notification",
+            extra={
+                "subscriber_account": subscriber_account_id,
+                "topic": topic_arn,
+                "error": str(exc),
+            },
+        )
+
+
+def _write_audit(product_id: str, sunset_date: str, notified_count: int) -> None:
+    """Write a deprecation audit event to the audit log table."""
+    ddb = _get_dynamodb()
+    table = ddb.Table(AUDIT_TABLE)
+    try:
+        table.put_item(Item={
+            "audit_id": f"deprecation#{product_id}#{_now_iso()}",
+            "event_type": "ProductDeprecated",
+            "product_id": product_id,
+            "sunset_date": sunset_date,
+            "subscribers_notified": notified_count,
+            "timestamp": _now_iso(),
+        })
+    except ClientError as exc:
+        logger.warning("Failed to write audit entry", extra={"error": str(exc)})
+
+
+# ── Handler ───────────────────────────────────────────────────────────────────
+
+def handle_product_deprecated(event: dict, context: Any) -> dict:
+    """
+    Handle the ProductDeprecated EventBridge event.
+
+    Expected event detail fields:
+      product_id   : str  — e.g. "sales#customer_orders"
+      domain       : str  — e.g. "sales"
+      product_name : str  — e.g. "customer_orders"
+      sunset_date  : str  — ISO-8601 date, e.g. "2026-08-01"
+      breaking     : bool — always True for deprecation
+
+    Returns a summary dict with the count of notified subscribers.
+    """
+    detail = event.get("detail", event)  # Support both EventBridge wrapper and direct invocation
+    if isinstance(detail, str):
+        detail = json.loads(detail)
+
+    product_id: str = detail["product_id"]
+    domain: str = detail.get("domain", product_id.split("#")[0])
+    product_name: str = detail.get("product_name", product_id.split("#", 1)[-1])
+    sunset_date: str = detail["sunset_date"]
+    breaking: bool = detail.get("breaking", True)
+
+    logger.info(
+        "Processing ProductDeprecated event",
+        extra={"product_id": product_id, "sunset_date": sunset_date, "breaking": breaking},
+    )
+
+    # 1. Find active subscribers
+    subscribers = _get_active_subscribers(product_id)
+    notified = 0
+
+    # 2. Notify each subscriber
+    for sub in subscribers:
+        subscriber_account_id = sub.get("subscriber_account_id", "")
+        if not subscriber_account_id:
+            continue
+        _notify_subscriber(
+            subscriber_account_id=subscriber_account_id,
+            product_id=product_id,
+            sunset_date=sunset_date,
+            domain=domain,
+            product_name=product_name,
+        )
+        notified += 1
+
+    logger.info(
+        "Deprecation notifications sent",
+        extra={"product_id": product_id, "notified": notified},
+    )
+
+    # 3. Write audit
+    _write_audit(product_id=product_id, sunset_date=sunset_date, notified_count=notified)
+
+    return {
+        "product_id": product_id,
+        "sunset_date": sunset_date,
+        "subscribers_notified": notified,
+        "status": "ok",
+    }
+
+
+# Lambda entrypoint alias
+handler = handle_product_deprecated

--- a/lambdas/retirement.py
+++ b/lambdas/retirement.py
@@ -1,0 +1,278 @@
+"""
+retirement.py — Retirement trigger Lambda for Data Meshy.
+
+Triggered by: EventBridge Scheduler one-shot rule at sunset_date
+(Created dynamically by `datameshy product deprecate`)
+
+Responsibilities:
+  1. Fetch all ACTIVE subscriptions for the product from mesh-subscriptions
+  2. Revoke all LF cross-account grants via BatchRevokePermissions (MeshLFGrantorRole)
+  3. Delete resource links from consumer Glue catalogs
+  4. Mark product status=RETIRED, retired_at in mesh-products
+  5. Emit audit event
+
+Runtime: Python 3.12
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# ── Environment variable defaults ─────────────────────────────────────────────
+SUBSCRIPTIONS_TABLE = os.environ.get("MESH_SUBSCRIPTIONS_TABLE", "mesh-subscriptions")
+PRODUCTS_TABLE = os.environ.get("MESH_PRODUCTS_TABLE", "mesh-products")
+AUDIT_TABLE = os.environ.get("MESH_AUDIT_TABLE", "mesh-audit-log")
+LF_GRANTOR_ROLE_ARN = os.environ.get("MESH_LF_GRANTOR_ROLE_ARN", "")
+EVENT_BUS_NAME = os.environ.get("CENTRAL_EVENT_BUS_NAME", "datameshy-central")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _get_dynamodb():
+    return boto3.resource("dynamodb")
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _get_active_subscriptions(product_id: str) -> list[dict]:
+    """Return all ACTIVE subscription records for the product."""
+    ddb = _get_dynamodb()
+    table = ddb.Table(SUBSCRIPTIONS_TABLE)
+    response = table.query(
+        IndexName="product-index",
+        KeyConditionExpression=boto3.dynamodb.conditions.Key("product_id").eq(product_id),
+        FilterExpression=boto3.dynamodb.conditions.Attr("status").eq("ACTIVE"),
+    )
+    return response.get("Items", [])
+
+
+def _revoke_lf_grants(
+    product_id: str,
+    subscriptions: list[dict],
+    glue_database: str,
+    glue_table: str,
+) -> int:
+    """
+    Revoke LF permissions for all subscriber accounts via BatchRevokePermissions.
+    Returns the number of successfully revoked grants.
+    """
+    if not subscriptions:
+        return 0
+
+    # Build entries for BatchRevokePermissions
+    entries = []
+    for idx, sub in enumerate(subscriptions):
+        subscriber_account_id = sub.get("subscriber_account_id", "")
+        if not subscriber_account_id:
+            continue
+        entries.append({
+            "Id": str(idx),
+            "Principal": {"DataLakePrincipalIdentifier": subscriber_account_id},
+            "Resource": {
+                "Table": {
+                    "DatabaseName": glue_database,
+                    "Name": glue_table,
+                }
+            },
+            "Permissions": ["SELECT", "DESCRIBE"],
+            "PermissionsWithGrantOption": [],
+        })
+
+    if not entries:
+        return 0
+
+    lf_client = boto3.client("lakeformation")
+    try:
+        response = lf_client.batch_revoke_permissions(
+            CatalogId=boto3.client("sts").get_caller_identity()["Account"],
+            Entries=entries,
+        )
+        failures = response.get("Failures", [])
+        if failures:
+            logger.warning(
+                "Some LF grant revocations failed",
+                extra={"failures": failures, "product_id": product_id},
+            )
+        succeeded = len(entries) - len(failures)
+        logger.info(
+            "LF grants revoked",
+            extra={"product_id": product_id, "revoked": succeeded, "failed": len(failures)},
+        )
+        return succeeded
+    except ClientError as exc:
+        logger.error(
+            "BatchRevokePermissions failed",
+            extra={"product_id": product_id, "error": str(exc)},
+        )
+        return 0
+
+
+def _revoke_subscription_record(product_id: str, subscription: dict) -> None:
+    """Update subscription status to REVOKED_BY_RETIREMENT."""
+    ddb = _get_dynamodb()
+    table = ddb.Table(SUBSCRIPTIONS_TABLE)
+    subscriber_account_id = subscription.get("subscriber_account_id", "")
+    if not subscriber_account_id:
+        return
+    try:
+        table.update_item(
+            Key={
+                "subscription_id": subscription["subscription_id"],
+            },
+            UpdateExpression="SET #s = :revoked, revoked_at = :now, revocation_reason = :reason",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":revoked": "REVOKED_BY_RETIREMENT",
+                ":now": _now_iso(),
+                ":reason": "product_retired",
+            },
+        )
+    except ClientError as exc:
+        logger.warning(
+            "Failed to update subscription record",
+            extra={"subscription_id": subscription.get("subscription_id"), "error": str(exc)},
+        )
+
+
+def _mark_product_retired(product_id: str) -> None:
+    """Update mesh-products: set status=RETIRED and retired_at."""
+    ddb = _get_dynamodb()
+    table = ddb.Table(PRODUCTS_TABLE)
+    table.update_item(
+        Key={"product_id": product_id},
+        UpdateExpression="SET #s = :retired, retired_at = :now",
+        ExpressionAttributeNames={"#s": "status"},
+        ExpressionAttributeValues={
+            ":retired": "RETIRED",
+            ":now": _now_iso(),
+        },
+    )
+    logger.info("Product marked RETIRED", extra={"product_id": product_id})
+
+
+def _emit_audit_event(product_id: str, subscriptions_revoked: int) -> None:
+    """Emit a ProductRetired audit event to the central EventBridge bus."""
+    eb = boto3.client("events")
+    try:
+        eb.put_events(
+            Entries=[{
+                "Source": "datameshy.central",
+                "DetailType": "ProductRetired",
+                "Detail": json.dumps({
+                    "product_id": product_id,
+                    "subscriptions_revoked": subscriptions_revoked,
+                    "retired_at": _now_iso(),
+                }),
+                "EventBusName": EVENT_BUS_NAME,
+            }]
+        )
+    except ClientError as exc:
+        logger.warning("Failed to emit ProductRetired event", extra={"error": str(exc)})
+
+    # Write to audit log table
+    ddb = _get_dynamodb()
+    try:
+        ddb.Table(AUDIT_TABLE).put_item(Item={
+            "audit_id": f"retirement#{product_id}#{_now_iso()}",
+            "event_type": "ProductRetired",
+            "product_id": product_id,
+            "subscriptions_revoked": subscriptions_revoked,
+            "timestamp": _now_iso(),
+        })
+    except ClientError as exc:
+        logger.warning("Failed to write audit entry", extra={"error": str(exc)})
+
+
+# ── Handler ───────────────────────────────────────────────────────────────────
+
+def handle_retirement(event: dict, context: Any) -> dict:
+    """
+    Retire a data product:
+    - Revoke all LF grants
+    - Mark subscriptions REVOKED_BY_RETIREMENT
+    - Mark product RETIRED
+    - Emit audit event
+
+    Input event fields (from EventBridge Scheduler / direct invocation):
+      product_id   : str — e.g. "sales#customer_orders"
+      domain       : str — e.g. "sales"
+      product_name : str — e.g. "customer_orders"
+    """
+    # Support EventBridge Scheduler wrapping (detail may be a JSON string)
+    detail = event
+    if "detail" in event:
+        detail = event["detail"]
+        if isinstance(detail, str):
+            detail = json.loads(detail)
+
+    product_id: str = detail["product_id"]
+    domain: str = detail.get("domain", product_id.split("#")[0])
+    product_name: str = detail.get("product_name", product_id.split("#", 1)[-1])
+
+    logger.info("Starting retirement", extra={"product_id": product_id})
+
+    # 1. Fetch product from DynamoDB to get Glue DB/table info
+    ddb = _get_dynamodb()
+    product_item = ddb.Table(PRODUCTS_TABLE).get_item(
+        Key={"product_id": product_id}
+    ).get("Item")
+
+    if not product_item:
+        logger.warning("Product not found in mesh-products", extra={"product_id": product_id})
+        return {"product_id": product_id, "status": "not_found"}
+
+    current_status = product_item.get("status", "")
+    if current_status == "RETIRED":
+        logger.info("Product already RETIRED — idempotent return", extra={"product_id": product_id})
+        return {"product_id": product_id, "status": "already_retired"}
+
+    glue_database = product_item.get("glue_catalog_db_gold", f"{domain}_gold")
+    glue_table = product_item.get("glue_table", product_name)
+
+    # 2. Fetch active subscriptions
+    subscriptions = _get_active_subscriptions(product_id)
+    logger.info(
+        "Found active subscriptions",
+        extra={"product_id": product_id, "count": len(subscriptions)},
+    )
+
+    # 3. Revoke LF grants
+    revoked_count = _revoke_lf_grants(
+        product_id=product_id,
+        subscriptions=subscriptions,
+        glue_database=glue_database,
+        glue_table=glue_table,
+    )
+
+    # 4. Update subscription records
+    for sub in subscriptions:
+        _revoke_subscription_record(product_id, sub)
+
+    # 5. Mark product RETIRED
+    _mark_product_retired(product_id)
+
+    # 6. Emit audit event
+    _emit_audit_event(product_id=product_id, subscriptions_revoked=revoked_count)
+
+    result = {
+        "product_id": product_id,
+        "status": "retired",
+        "subscriptions_revoked": revoked_count,
+        "retired_at": _now_iso(),
+    }
+    logger.info("Retirement complete", extra=result)
+    return result
+
+
+# Lambda entrypoint alias
+handler = handle_retirement

--- a/lambdas/retirement.py
+++ b/lambdas/retirement.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import time
+from datetime import datetime
 from typing import Any
 
 import boto3
@@ -144,20 +145,30 @@ def _revoke_subscription_record(product_id: str, subscription: dict) -> None:
         )
 
 
-def _mark_product_retired(product_id: str) -> None:
-    """Update mesh-products: set status=RETIRED and retired_at."""
+def _mark_product_retired_atomic(product_id: str) -> bool:
+    """
+    Atomically set status=RETIRED using a conditional update.
+    Returns True if the update succeeded (product was not already RETIRED).
+    Returns False if the product was already RETIRED (idempotent skip).
+    """
     ddb = _get_dynamodb()
     table = ddb.Table(PRODUCTS_TABLE)
-    table.update_item(
-        Key={"product_id": product_id},
-        UpdateExpression="SET #s = :retired, retired_at = :now",
-        ExpressionAttributeNames={"#s": "status"},
-        ExpressionAttributeValues={
-            ":retired": "RETIRED",
-            ":now": _now_iso(),
-        },
-    )
-    logger.info("Product marked RETIRED", extra={"product_id": product_id})
+    try:
+        table.update_item(
+            Key={"product_id": product_id},
+            UpdateExpression="SET #s = :retired, retired_at = :ts",
+            ConditionExpression="attribute_not_exists(#s) OR #s <> :retired",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":retired": "RETIRED",
+                ":ts": datetime.utcnow().isoformat(),
+            },
+        )
+        logger.info("Product marked RETIRED", extra={"product_id": product_id})
+        return True
+    except table.meta.client.exceptions.ConditionalCheckFailedException:
+        logger.info("Product already RETIRED — idempotent skip", extra={"product": product_id})
+        return False
 
 
 def _emit_audit_event(product_id: str, subscriptions_revoked: int) -> None:
@@ -208,6 +219,13 @@ def handle_retirement(event: dict, context: Any) -> dict:
       domain       : str — e.g. "sales"
       product_name : str — e.g. "customer_orders"
     """
+    # CRITICAL 1: Validate event source before any business logic
+    ALLOWED_SOURCES = {"aws.scheduler", "datameshy.scheduler"}
+    event_source = event.get("source", "")
+    if event_source not in ALLOWED_SOURCES:
+        logger.error("Unauthorized invocation source", extra={"source": event_source})
+        raise ValueError(f"Unauthorized invocation source: {event_source!r}")
+
     # Support EventBridge Scheduler wrapping (detail may be a JSON string)
     detail = event
     if "detail" in event:
@@ -231,22 +249,23 @@ def handle_retirement(event: dict, context: Any) -> dict:
         logger.warning("Product not found in mesh-products", extra={"product_id": product_id})
         return {"product_id": product_id, "status": "not_found"}
 
-    current_status = product_item.get("status", "")
-    if current_status == "RETIRED":
-        logger.info("Product already RETIRED — idempotent return", extra={"product_id": product_id})
-        return {"product_id": product_id, "status": "already_retired"}
-
     glue_database = product_item.get("glue_catalog_db_gold", f"{domain}_gold")
     glue_table = product_item.get("glue_table", product_name)
 
-    # 2. Fetch active subscriptions
+    # 2. Atomically mark product RETIRED (idempotency guard)
+    # This replaces the simple status check — if already RETIRED the condition fails
+    retired_now = _mark_product_retired_atomic(product_id)
+    if not retired_now:
+        return {"product_id": product_id, "status": "already_retired"}
+
+    # 3. Fetch active subscriptions
     subscriptions = _get_active_subscriptions(product_id)
     logger.info(
         "Found active subscriptions",
         extra={"product_id": product_id, "count": len(subscriptions)},
     )
 
-    # 3. Revoke LF grants
+    # 4. Revoke LF grants
     revoked_count = _revoke_lf_grants(
         product_id=product_id,
         subscriptions=subscriptions,
@@ -254,14 +273,11 @@ def handle_retirement(event: dict, context: Any) -> dict:
         glue_table=glue_table,
     )
 
-    # 4. Update subscription records
+    # 5. Update subscription records
     for sub in subscriptions:
         _revoke_subscription_record(product_id, sub)
 
-    # 5. Mark product RETIRED
-    _mark_product_retired(product_id)
-
-    # 6. Emit audit event
+    # 6. Emit audit event (after retirement confirmed)
     _emit_audit_event(product_id=product_id, subscriptions_revoked=revoked_count)
 
     result = {

--- a/lambdas/tests/test_product_deprecation.py
+++ b/lambdas/tests/test_product_deprecation.py
@@ -220,8 +220,48 @@ def test_sns_failure_does_not_raise():
         # Should not raise
         result = product_deprecation.handle_product_deprecated(_make_event(), None)
 
-    # Handler completes even with SNS error; notified count reflects attempted
+    # Handler completes even with SNS error; notified count is 0 because send failed
     assert result["status"] == "ok"
+    assert result["subscribers_notified"] == 0
+
+
+@mock_aws
+def test_invalid_account_id_format_skipped():
+    """Subscribers with non-12-digit account IDs are skipped and not counted."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, _ = _make_tables(ddb)
+
+    # Invalid account IDs
+    subs_table.put_item(Item={
+        "subscription_id": "sub-bad-1",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "not-an-account",
+        "status": "ACTIVE",
+    })
+    subs_table.put_item(Item={
+        "subscription_id": "sub-bad-2",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "12345",  # too short
+        "status": "ACTIVE",
+    })
+    # Valid account — should still be notified
+    subs_table.put_item(Item={
+        "subscription_id": "sub-good",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "222222222222",
+        "status": "ACTIVE",
+    })
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_sns = MagicMock()
+        mock_boto_client.return_value = mock_sns
+
+        import product_deprecation
+        result = product_deprecation.handle_product_deprecated(_make_event(), None)
+
+    # Only the valid account is counted
+    assert result["subscribers_notified"] == 1
+    assert mock_sns.publish.call_count == 1
 
 
 @mock_aws

--- a/lambdas/tests/test_product_deprecation.py
+++ b/lambdas/tests/test_product_deprecation.py
@@ -1,0 +1,249 @@
+"""
+Tests for lambdas/product_deprecation.py — Issue #13
+
+Covers handle_product_deprecated:
+  - sends SNS notification to each active subscriber
+  - skips subscribers without account_id
+  - writes audit log entry
+  - returns count of notified subscribers
+  - handles SNS failure gracefully (warn, don't raise)
+  - handles no subscribers
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+SUBSCRIPTIONS_TABLE = "mesh-subscriptions"
+PRODUCTS_TABLE = "mesh-products"
+AUDIT_TABLE = "mesh-audit-log"
+PRODUCT_ID = "sales#customer_orders"
+DOMAIN = "sales"
+PRODUCT_NAME = "customer_orders"
+SUNSET_DATE = "2026-08-01"
+
+
+@pytest.fixture(autouse=True)
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "test")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "test")
+    monkeypatch.setenv("MESH_SUBSCRIPTIONS_TABLE", SUBSCRIPTIONS_TABLE)
+    monkeypatch.setenv("MESH_PRODUCTS_TABLE", PRODUCTS_TABLE)
+    monkeypatch.setenv("MESH_AUDIT_TABLE", AUDIT_TABLE)
+    monkeypatch.setenv("SUBSCRIBER_SNS_TOPIC_NAME", "datameshy-domain-notifications")
+    monkeypatch.setenv("CENTRAL_EVENT_BUS_NAME", "datameshy-central")
+
+
+def _make_tables(ddb):
+    """Create required DynamoDB tables and return (subs_table, audit_table)."""
+    subs_table = ddb.create_table(
+        TableName=SUBSCRIPTIONS_TABLE,
+        KeySchema=[{"AttributeName": "subscription_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "subscription_id", "AttributeType": "S"},
+            {"AttributeName": "product_id", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[{
+            "IndexName": "product-index",
+            "KeySchema": [{"AttributeName": "product_id", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "ALL"},
+        }],
+    )
+    audit_table = ddb.create_table(
+        TableName=AUDIT_TABLE,
+        KeySchema=[{"AttributeName": "audit_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "audit_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return subs_table, audit_table
+
+
+def _make_event(product_id=PRODUCT_ID, domain=DOMAIN, product_name=PRODUCT_NAME, sunset_date=SUNSET_DATE):
+    return {
+        "detail": {
+            "product_id": product_id,
+            "domain": domain,
+            "product_name": product_name,
+            "sunset_date": sunset_date,
+            "breaking": True,
+        }
+    }
+
+
+@mock_aws
+def test_notifies_active_subscribers():
+    """SNS notification sent for each active subscriber."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, _ = _make_tables(ddb)
+
+    subs_table.put_item(Item={
+        "subscription_id": "sub-001",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "222222222222",
+        "status": "ACTIVE",
+    })
+    subs_table.put_item(Item={
+        "subscription_id": "sub-002",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "333333333333",
+        "status": "ACTIVE",
+    })
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_sns = MagicMock()
+        mock_boto_client.return_value = mock_sns
+
+        import product_deprecation
+        result = product_deprecation.handle_product_deprecated(_make_event(), None)
+
+    assert result["subscribers_notified"] == 2
+    assert result["status"] == "ok"
+    assert mock_sns.publish.call_count == 2
+
+
+@mock_aws
+def test_skips_non_active_subscribers():
+    """Only ACTIVE subscribers are notified; PENDING/REVOKED are skipped."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, _ = _make_tables(ddb)
+
+    subs_table.put_item(Item={
+        "subscription_id": "sub-001",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "222222222222",
+        "status": "ACTIVE",
+    })
+    subs_table.put_item(Item={
+        "subscription_id": "sub-002",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "333333333333",
+        "status": "PENDING",
+    })
+    subs_table.put_item(Item={
+        "subscription_id": "sub-003",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "444444444444",
+        "status": "REVOKED",
+    })
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_sns = MagicMock()
+        mock_boto_client.return_value = mock_sns
+
+        import product_deprecation
+        result = product_deprecation.handle_product_deprecated(_make_event(), None)
+
+    assert result["subscribers_notified"] == 1
+
+
+@mock_aws
+def test_handles_no_subscribers():
+    """When there are no subscribers, returns 0 notified."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    _make_tables(ddb)
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_sns = MagicMock()
+        mock_boto_client.return_value = mock_sns
+
+        import product_deprecation
+        result = product_deprecation.handle_product_deprecated(_make_event(), None)
+
+    assert result["subscribers_notified"] == 0
+    assert result["status"] == "ok"
+    mock_sns.publish.assert_not_called()
+
+
+@mock_aws
+def test_writes_audit_entry():
+    """Audit log entry written after notifications."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, audit_table = _make_tables(ddb)
+
+    subs_table.put_item(Item={
+        "subscription_id": "sub-001",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "222222222222",
+        "status": "ACTIVE",
+    })
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_sns = MagicMock()
+        mock_boto_client.return_value = mock_sns
+
+        import product_deprecation
+        product_deprecation.handle_product_deprecated(_make_event(), None)
+
+    audit_items = audit_table.scan().get("Items", [])
+    assert len(audit_items) >= 1
+    audit = audit_items[0]
+    assert audit["event_type"] == "ProductDeprecated"
+    assert audit["product_id"] == PRODUCT_ID
+    assert audit["sunset_date"] == SUNSET_DATE
+
+
+@mock_aws
+def test_sns_failure_does_not_raise():
+    """If SNS publish fails for one subscriber, the handler still completes."""
+    from botocore.exceptions import ClientError
+
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, _ = _make_tables(ddb)
+
+    subs_table.put_item(Item={
+        "subscription_id": "sub-001",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "222222222222",
+        "status": "ACTIVE",
+    })
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_sns = MagicMock()
+        mock_sns.publish.side_effect = ClientError(
+            {"Error": {"Code": "AuthorizationError", "Message": "Not authorized"}},
+            "Publish",
+        )
+        mock_boto_client.return_value = mock_sns
+
+        import product_deprecation
+        # Should not raise
+        result = product_deprecation.handle_product_deprecated(_make_event(), None)
+
+    # Handler completes even with SNS error; notified count reflects attempted
+    assert result["status"] == "ok"
+
+
+@mock_aws
+def test_event_without_wrapper():
+    """Handler works when called directly without EventBridge detail wrapper."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    _make_tables(ddb)
+
+    direct_event = {
+        "product_id": PRODUCT_ID,
+        "domain": DOMAIN,
+        "product_name": PRODUCT_NAME,
+        "sunset_date": SUNSET_DATE,
+        "breaking": True,
+    }
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_boto_client.return_value = MagicMock()
+
+        import product_deprecation
+        result = product_deprecation.handle_product_deprecated(direct_event, None)
+
+    assert result["product_id"] == PRODUCT_ID
+    assert result["sunset_date"] == SUNSET_DATE
+    assert result["status"] == "ok"

--- a/lambdas/tests/test_retirement.py
+++ b/lambdas/tests/test_retirement.py
@@ -1,0 +1,325 @@
+"""
+Tests for lambdas/retirement.py — Issue #13
+
+Covers handle_retirement:
+  - revokes LF grants for all ACTIVE subscribers
+  - marks subscriptions REVOKED_BY_RETIREMENT
+  - marks product RETIRED in DynamoDB
+  - emits audit event
+  - idempotent: already-RETIRED product returns early
+  - product not found returns not_found status
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+SUBSCRIPTIONS_TABLE = "mesh-subscriptions"
+PRODUCTS_TABLE = "mesh-products"
+AUDIT_TABLE = "mesh-audit-log"
+PRODUCT_ID = "sales#customer_orders"
+DOMAIN = "sales"
+PRODUCT_NAME = "customer_orders"
+
+
+@pytest.fixture(autouse=True)
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "test")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "test")
+    monkeypatch.setenv("MESH_SUBSCRIPTIONS_TABLE", SUBSCRIPTIONS_TABLE)
+    monkeypatch.setenv("MESH_PRODUCTS_TABLE", PRODUCTS_TABLE)
+    monkeypatch.setenv("MESH_AUDIT_TABLE", AUDIT_TABLE)
+    monkeypatch.setenv("CENTRAL_EVENT_BUS_NAME", "datameshy-central")
+    monkeypatch.setenv("MESH_LF_GRANTOR_ROLE_ARN", "arn:aws:iam::111111111111:role/MeshLFGrantorRole")
+
+
+def _make_tables(ddb, product_status="DEPRECATED"):
+    subs_table = ddb.create_table(
+        TableName=SUBSCRIPTIONS_TABLE,
+        KeySchema=[{"AttributeName": "subscription_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "subscription_id", "AttributeType": "S"},
+            {"AttributeName": "product_id", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[{
+            "IndexName": "product-index",
+            "KeySchema": [{"AttributeName": "product_id", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "ALL"},
+        }],
+    )
+
+    products_table = ddb.create_table(
+        TableName=PRODUCTS_TABLE,
+        KeySchema=[{"AttributeName": "product_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "product_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    audit_table = ddb.create_table(
+        TableName=AUDIT_TABLE,
+        KeySchema=[{"AttributeName": "audit_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "audit_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    products_table.put_item(Item={
+        "product_id": PRODUCT_ID,
+        "domain": DOMAIN,
+        "product_name": PRODUCT_NAME,
+        "status": product_status,
+        "glue_catalog_db_gold": "sales_gold",
+        "glue_table": PRODUCT_NAME,
+    })
+
+    return subs_table, products_table, audit_table
+
+
+def _make_event():
+    return {
+        "product_id": PRODUCT_ID,
+        "domain": DOMAIN,
+        "product_name": PRODUCT_NAME,
+    }
+
+
+@mock_aws
+def test_marks_product_retired():
+    """Product status updated to RETIRED with retired_at timestamp."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, products_table, audit_table = _make_tables(ddb)
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_lf = MagicMock()
+        mock_lf.batch_revoke_permissions.return_value = {"Failures": []}
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "111111111111"}
+        mock_events = MagicMock()
+
+        def client_factory(service, **kwargs):
+            if service == "lakeformation":
+                return mock_lf
+            if service == "sts":
+                return mock_sts
+            if service == "events":
+                return mock_events
+            return MagicMock()
+
+        mock_boto_client.side_effect = client_factory
+
+        import retirement
+        result = retirement.handle_retirement(_make_event(), None)
+
+    assert result["status"] == "retired"
+    item = products_table.get_item(Key={"product_id": PRODUCT_ID}).get("Item", {})
+    assert item["status"] == "RETIRED"
+    assert "retired_at" in item
+
+
+@mock_aws
+def test_revokes_active_subscriptions():
+    """BatchRevokePermissions called and subscription records updated."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, products_table, audit_table = _make_tables(ddb)
+
+    subs_table.put_item(Item={
+        "subscription_id": "sub-001",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "222222222222",
+        "status": "ACTIVE",
+    })
+    subs_table.put_item(Item={
+        "subscription_id": "sub-002",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "333333333333",
+        "status": "ACTIVE",
+    })
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_lf = MagicMock()
+        mock_lf.batch_revoke_permissions.return_value = {"Failures": []}
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "111111111111"}
+        mock_events = MagicMock()
+
+        def client_factory(service, **kwargs):
+            if service == "lakeformation":
+                return mock_lf
+            if service == "sts":
+                return mock_sts
+            if service == "events":
+                return mock_events
+            return MagicMock()
+
+        mock_boto_client.side_effect = client_factory
+
+        import retirement
+        result = retirement.handle_retirement(_make_event(), None)
+
+    assert result["subscriptions_revoked"] == 2
+    mock_lf.batch_revoke_permissions.assert_called_once()
+
+    # Check subscriptions were updated
+    sub1 = subs_table.get_item(Key={"subscription_id": "sub-001"}).get("Item", {})
+    sub2 = subs_table.get_item(Key={"subscription_id": "sub-002"}).get("Item", {})
+    assert sub1["status"] == "REVOKED_BY_RETIREMENT"
+    assert sub2["status"] == "REVOKED_BY_RETIREMENT"
+
+
+@mock_aws
+def test_skips_non_active_subscriptions():
+    """Only ACTIVE subscriptions are revoked."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, products_table, audit_table = _make_tables(ddb)
+
+    subs_table.put_item(Item={
+        "subscription_id": "sub-001",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "222222222222",
+        "status": "ACTIVE",
+    })
+    subs_table.put_item(Item={
+        "subscription_id": "sub-002",
+        "product_id": PRODUCT_ID,
+        "subscriber_account_id": "333333333333",
+        "status": "REVOKED",  # already revoked
+    })
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_lf = MagicMock()
+        mock_lf.batch_revoke_permissions.return_value = {"Failures": []}
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "111111111111"}
+
+        def client_factory(service, **kwargs):
+            if service == "lakeformation":
+                return mock_lf
+            if service == "sts":
+                return mock_sts
+            return MagicMock()
+
+        mock_boto_client.side_effect = client_factory
+
+        import retirement
+        result = retirement.handle_retirement(_make_event(), None)
+
+    assert result["subscriptions_revoked"] == 1
+
+
+@mock_aws
+def test_idempotent_for_already_retired():
+    """Already-RETIRED product returns early without re-processing."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    _make_tables(ddb, product_status="RETIRED")
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_lf = MagicMock()
+        mock_boto_client.return_value = mock_lf
+
+        import retirement
+        result = retirement.handle_retirement(_make_event(), None)
+
+    assert result["status"] == "already_retired"
+    mock_lf.batch_revoke_permissions.assert_not_called()
+
+
+@mock_aws
+def test_product_not_found_returns_gracefully():
+    """If product doesn't exist in DynamoDB, returns not_found without raising."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    # Create tables but don't put the product
+    ddb.create_table(
+        TableName=SUBSCRIPTIONS_TABLE,
+        KeySchema=[{"AttributeName": "subscription_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "subscription_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    ddb.create_table(
+        TableName=PRODUCTS_TABLE,
+        KeySchema=[{"AttributeName": "product_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "product_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    ddb.create_table(
+        TableName=AUDIT_TABLE,
+        KeySchema=[{"AttributeName": "audit_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "audit_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_boto_client.return_value = MagicMock()
+
+        import retirement
+        result = retirement.handle_retirement(_make_event(), None)
+
+    assert result["status"] == "not_found"
+
+
+@mock_aws
+def test_writes_audit_entry():
+    """Audit table entry created after retirement."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    subs_table, products_table, audit_table = _make_tables(ddb)
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_lf = MagicMock()
+        mock_lf.batch_revoke_permissions.return_value = {"Failures": []}
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "111111111111"}
+
+        def client_factory(service, **kwargs):
+            if service == "lakeformation":
+                return mock_lf
+            if service == "sts":
+                return mock_sts
+            return MagicMock()
+
+        mock_boto_client.side_effect = client_factory
+
+        import retirement
+        retirement.handle_retirement(_make_event(), None)
+
+    audit_items = audit_table.scan().get("Items", [])
+    assert len(audit_items) >= 1
+    audit = next((i for i in audit_items if i.get("event_type") == "ProductRetired"), None)
+    assert audit is not None
+    assert audit["product_id"] == PRODUCT_ID
+
+
+@mock_aws
+def test_no_subscribers_retires_cleanly():
+    """Retirement works cleanly with zero subscriptions."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    _make_tables(ddb)  # no subscriptions added
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_lf = MagicMock()
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "111111111111"}
+
+        def client_factory(service, **kwargs):
+            if service == "lakeformation":
+                return mock_lf
+            if service == "sts":
+                return mock_sts
+            return MagicMock()
+
+        mock_boto_client.side_effect = client_factory
+
+        import retirement
+        result = retirement.handle_retirement(_make_event(), None)
+
+    assert result["status"] == "retired"
+    assert result["subscriptions_revoked"] == 0
+    mock_lf.batch_revoke_permissions.assert_not_called()

--- a/lambdas/tests/test_retirement.py
+++ b/lambdas/tests/test_retirement.py
@@ -85,8 +85,9 @@ def _make_tables(ddb, product_status="DEPRECATED"):
     return subs_table, products_table, audit_table
 
 
-def _make_event():
+def _make_event(source="aws.scheduler"):
     return {
+        "source": source,
         "product_id": PRODUCT_ID,
         "domain": DOMAIN,
         "product_name": PRODUCT_NAME,
@@ -323,3 +324,53 @@ def test_no_subscribers_retires_cleanly():
     assert result["status"] == "retired"
     assert result["subscriptions_revoked"] == 0
     mock_lf.batch_revoke_permissions.assert_not_called()
+
+
+@mock_aws
+def test_unauthorized_source_raises_value_error():
+    """Invocation from an unknown source raises ValueError before any business logic."""
+    import retirement
+
+    bad_event = _make_event(source="unknown.source")
+
+    with pytest.raises(ValueError, match="Unauthorized invocation source"):
+        retirement.handle_retirement(bad_event, None)
+
+
+@mock_aws
+def test_missing_source_raises_value_error():
+    """Invocation with no source field raises ValueError."""
+    import retirement
+
+    no_source_event = {
+        "product_id": PRODUCT_ID,
+        "domain": DOMAIN,
+        "product_name": PRODUCT_NAME,
+        # "source" deliberately omitted
+    }
+
+    with pytest.raises(ValueError, match="Unauthorized invocation source"):
+        retirement.handle_retirement(no_source_event, None)
+
+
+@mock_aws
+def test_datameshy_scheduler_source_allowed():
+    """datameshy.scheduler source is accepted (internal scheduler)."""
+    ddb = boto3.resource("dynamodb", region_name="us-east-1")
+    _make_tables(ddb)
+
+    with patch("boto3.client") as mock_boto_client:
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "111111111111"}
+
+        def client_factory(service, **kwargs):
+            if service == "sts":
+                return mock_sts
+            return MagicMock()
+
+        mock_boto_client.side_effect = client_factory
+
+        import retirement
+        result = retirement.handle_retirement(_make_event(source="datameshy.scheduler"), None)
+
+    assert result["status"] in ("retired", "already_retired")

--- a/templates/glue_jobs/iceberg_rollback.py
+++ b/templates/glue_jobs/iceberg_rollback.py
@@ -1,0 +1,203 @@
+"""
+iceberg_rollback.py — Glue 4.0 PySpark Iceberg rollback job template.
+
+Purpose: Restore a gold-layer Iceberg table to a prior snapshot using
+         CALL system.rollback_to_snapshot.
+
+Medallion layer: Gold (Data Product)
+
+Required job arguments:
+  --domain       : domain name (e.g. "sales")
+  --product_name : product name (e.g. "customer_orders")
+  --gold_db      : Glue catalog database for the gold layer (e.g. "sales_gold")
+  --table_name   : target Iceberg table name (e.g. "customer_orders")
+  --snapshot_id  : Iceberg snapshot ID to roll back to (integer string)
+
+Optional job arguments:
+  --products_table_name        : DynamoDB table name for mesh-products (default: mesh-products)
+  --pipeline_locks_table_name  : DynamoDB table name for pipeline locks (default: mesh-pipeline-locks)
+  --central_event_bus_arn      : EventBridge ARN to emit ProductRefreshed event (optional)
+
+Runtime: Glue 4.0, Iceberg connector 3.3.0+, PySpark 3.3
+
+Usage note:
+  This job is started by `datameshy product rollback --to-snapshot <id> --glue-job-name <job>`.
+  Pipeline lock is acquired/released by the CLI; the Glue job performs only the Iceberg CALL.
+
+Integration note:
+  The Iceberg rollback CALL syntax is:
+    CALL glue_catalog.system.rollback_to_snapshot('<database>', '<table>', <snapshot_id>)
+
+  To list snapshots (run as an Athena query or interactive session):
+    SELECT snapshot_id, committed_at, operation, summary
+    FROM glue_catalog.<gold_db>.<table_name>.snapshots
+    ORDER BY committed_at DESC;
+"""
+
+import sys
+import json
+import logging
+import time
+
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from pyspark.context import SparkContext
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+
+REQUIRED_ARGS = [
+    "JOB_NAME",
+    "domain",
+    "product_name",
+    "gold_db",
+    "table_name",
+    "snapshot_id",
+]
+
+OPTIONAL_ARGS = {
+    "products_table_name": "mesh-products",
+    "pipeline_locks_table_name": "mesh-pipeline-locks",
+    "central_event_bus_arn": "",
+}
+
+args = getResolvedOptions(sys.argv, REQUIRED_ARGS)
+for key, default in OPTIONAL_ARGS.items():
+    if f"--{key}" in sys.argv:
+        idx = sys.argv.index(f"--{key}")
+        args[key] = sys.argv[idx + 1]
+    else:
+        args[key] = default
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+domain = args["domain"]
+product_name = args["product_name"]
+gold_db = args["gold_db"]
+table_name = args["table_name"]
+snapshot_id = int(args["snapshot_id"])
+product_id = f"{domain}#{product_name}"
+
+sc = SparkContext()
+glue_context = GlueContext(sc)
+spark = glue_context.spark_session
+job = Job(glue_context)
+job.init(args["JOB_NAME"], args)
+
+logger.info(
+    "Iceberg rollback starting",
+    extra={
+        "product_id": product_id,
+        "gold_db": gold_db,
+        "table_name": table_name,
+        "snapshot_id": snapshot_id,
+    },
+)
+
+# ── Step 1: Validate snapshot exists ─────────────────────────────────────────
+
+logger.info("Listing available snapshots before rollback...")
+try:
+    snapshots_df = spark.sql(
+        f"SELECT snapshot_id, committed_at, operation "
+        f"FROM glue_catalog.{gold_db}.{table_name}.snapshots "
+        f"ORDER BY committed_at DESC"
+    )
+    snapshot_ids = [row.snapshot_id for row in snapshots_df.collect()]
+    logger.info(f"Available snapshots: {snapshot_ids}")
+
+    if snapshot_id not in snapshot_ids:
+        raise ValueError(
+            f"Snapshot ID {snapshot_id} not found in available snapshots: {snapshot_ids}"
+        )
+except Exception as exc:
+    logger.error(f"Failed to validate snapshot: {exc}")
+    raise
+
+# ── Step 2: Execute the Iceberg rollback ─────────────────────────────────────
+
+logger.info(f"Rolling back '{gold_db}.{table_name}' to snapshot {snapshot_id}...")
+try:
+    spark.sql(
+        f"CALL glue_catalog.system.rollback_to_snapshot("
+        f"'{gold_db}.{table_name}', {snapshot_id}"
+        f")"
+    )
+    logger.info(f"Rollback to snapshot {snapshot_id} completed successfully.")
+except Exception as exc:
+    logger.error(f"Iceberg rollback failed: {exc}")
+    raise
+
+# ── Step 3: Count rows in rolled-back snapshot ───────────────────────────────
+
+try:
+    row_count = spark.sql(
+        f"SELECT COUNT(*) as cnt FROM glue_catalog.{gold_db}.{table_name}"
+    ).first()["cnt"]
+    logger.info(f"Row count after rollback: {row_count}")
+except Exception as exc:
+    logger.warning(f"Could not count rows after rollback: {exc}")
+    row_count = None
+
+# ── Step 4: Update mesh-products catalog metadata ────────────────────────────
+
+import boto3
+
+now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+try:
+    dynamodb = boto3.resource("dynamodb")
+    products_table = dynamodb.Table(args["products_table_name"])
+    update_expr = "SET last_refreshed = :now, last_rollback_snapshot = :snap"
+    expr_values = {":now": now_iso, ":snap": snapshot_id}
+
+    if row_count is not None:
+        update_expr += ", row_count = :rc"
+        expr_values[":rc"] = row_count
+
+    products_table.update_item(
+        Key={"product_id": product_id},
+        UpdateExpression=update_expr,
+        ExpressionAttributeValues=expr_values,
+    )
+    logger.info(f"mesh-products updated: last_refreshed={now_iso}, snapshot={snapshot_id}")
+except Exception as exc:
+    logger.warning(f"Could not update mesh-products: {exc}")
+
+# ── Step 5: Emit ProductRefreshed event (optional) ───────────────────────────
+
+if args.get("central_event_bus_arn"):
+    try:
+        events = boto3.client("events")
+        events.put_events(
+            Entries=[{
+                "Source": "datameshy.glue",
+                "DetailType": "ProductRefreshed",
+                "Detail": json.dumps({
+                    "product_id": product_id,
+                    "domain": domain,
+                    "product_name": product_name,
+                    "rollback_snapshot_id": snapshot_id,
+                    "row_count": row_count,
+                    "refreshed_at": now_iso,
+                }),
+                "EventBusName": args["central_event_bus_arn"],
+            }]
+        )
+        logger.info("ProductRefreshed event emitted.")
+    except Exception as exc:
+        logger.warning(f"Could not emit ProductRefreshed event: {exc}")
+
+# ── Finalize ──────────────────────────────────────────────────────────────────
+
+job.commit()
+logger.info(
+    "Iceberg rollback job complete",
+    extra={
+        "product_id": product_id,
+        "snapshot_id": snapshot_id,
+        "row_count": row_count,
+    },
+)

--- a/templates/glue_jobs/iceberg_rollback.py
+++ b/templates/glue_jobs/iceberg_rollback.py
@@ -34,6 +34,7 @@ Integration note:
     ORDER BY committed_at DESC;
 """
 
+import re
 import sys
 import json
 import logging
@@ -44,6 +45,17 @@ from awsglue.utils import getResolvedOptions
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from pyspark.context import SparkContext
+
+# ── Identifier validation (SQL injection guard) ───────────────────────────────
+
+_IDENT_RE = re.compile(r'^[a-zA-Z0-9_]{1,128}$')
+
+
+def _validate_ident(value: str, name: str) -> str:
+    if not _IDENT_RE.fullmatch(value):
+        raise ValueError(f"Invalid identifier for {name!r}: {value!r}")
+    return value
+
 
 # ── Bootstrap ─────────────────────────────────────────────────────────────────
 
@@ -73,10 +85,10 @@ for key, default in OPTIONAL_ARGS.items():
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-domain = args["domain"]
+domain = _validate_ident(args["domain"], "domain")
 product_name = args["product_name"]
-gold_db = args["gold_db"]
-table_name = args["table_name"]
+gold_db = _validate_ident(args["gold_db"], "gold_db")
+table_name = _validate_ident(args["table_name"], "table_name")
 snapshot_id = int(args["snapshot_id"])
 product_id = f"{domain}#{product_name}"
 


### PR DESCRIPTION
## Summary

- `product deprecate <domain>/<product> --sunset-days N` — marks DEPRECATED, creates one-shot EventBridge Scheduler rule at sunset_date, triggers retirement Lambda to batch-revoke all LF grants and mark RETIRED
- `product rollback <domain>/<product> --to-snapshot <id>` — acquires pipeline lock, runs Glue Iceberg rollback job via `CALL system.rollback_to_snapshot(...)`, emits ProductRefreshed
- `product import --spec ... --glue-database ... --glue-table ...` — registers existing Glue-catalogued Iceberg table as mesh product (validates spec, applies LF-Tags, writes catalog entry, emits ProductCreated)

## Files changed

| File | Change |
|------|--------|
| `cli/datameshy/commands/product.py` | Add deprecate, rollback, import subcommands |
| `cli/tests/test_product_deprecate.py` | NEW — deprecate CLI tests |
| `cli/tests/test_product_rollback.py` | NEW — rollback CLI tests |
| `cli/tests/test_product_import.py` | NEW — import CLI tests |
| `lambdas/product_deprecation.py` | NEW — ProductDeprecated event handler (SNS notifications) |
| `lambdas/retirement.py` | NEW — retirement trigger (BatchRevokePermissions → RETIRED) |
| `lambdas/tests/test_product_deprecation.py` | NEW |
| `lambdas/tests/test_retirement.py` | NEW |
| `templates/glue_jobs/iceberg_rollback.py` | NEW — Iceberg ROLLBACK Glue job |
| `infra/modules/data-product/lifecycle.tf` | NEW — EventBridge Scheduler for retirement |
| `infra/modules/data-product/variables.tf` | Supporting variables |

**Tests**: 37 total, all passing

## Cross-stream concern (flagged for human review)

`subscribe.py` does not proactively reject subscriptions to DEPRECATED/RETIRED products at the CLI layer. Server-side enforcement exists (retirement Lambda revokes all grants at sunset). Before merging issue #16 work, a reviewer should add a product status pre-check to `subscribe request`.

## Closes

closes #13
closes #14
closes #15