### PR TITLE
Phase 3 Stream 3: versioned example products (revenue_daily v1/v2, campaign_metrics)

### DIFF
--- a/examples/marketing-domain/README.md
+++ b/examples/marketing-domain/README.md
@@ -1,0 +1,22 @@
+# Marketing Domain — Example Data Products
+
+This directory contains example data products for the **marketing** domain.
+
+## Products
+
+| Product | Schema Version | Status | Classification | Description |
+|---|---|---|---|---|
+| [campaign_metrics](products/campaign_metrics/) | 1 | ACTIVE | internal | Daily campaign performance metrics by channel |
+
+## About this domain
+
+The marketing domain owns data products related to campaign performance, audience
+segments, and channel analytics. All products in this domain are `internal` — no PII
+is captured, and data is available to any authenticated domain team via the mesh catalog.
+
+## Browsing the catalog
+
+```bash
+datameshy catalog search --domain marketing
+datameshy catalog describe --name campaign_metrics
+```

--- a/examples/marketing-domain/products/campaign_metrics/README.md
+++ b/examples/marketing-domain/products/campaign_metrics/README.md
@@ -1,0 +1,57 @@
+# campaign_metrics
+
+**Domain**: marketing
+**Schema version**: 1
+**Classification**: internal
+**Status**: ACTIVE
+
+## Overview
+
+Daily aggregated campaign performance metrics by channel. This product tracks
+impressions, clicks, spend, and conversion rate per campaign per day.
+
+No PII is captured — all columns are aggregated metrics or non-personal identifiers.
+The `internal` classification means the product is available to any team within the
+organization via the data mesh catalog, but is not shared externally.
+
+## Schema
+
+| Column | Type | Nullable | Description |
+|---|---|---|---|
+| campaign_id | string | NOT NULL | Unique campaign identifier |
+| channel | string | yes | Marketing channel (email, paid-search, social, …) |
+| impressions | long | yes | Total ad impressions for the day |
+| clicks | long | yes | Total clicks for the day |
+| spend | decimal(10,2) | yes | Total spend in USD for the day |
+| conversion_rate | double | yes | Clicks-to-conversion ratio |
+
+Partition key: `channel` (identity transform).
+
+## Quality Rules
+
+- `campaign_id` must be complete (no nulls) — threshold 100 %
+- `spend` must be positive (> 0)
+
+## SLA
+
+- Refresh frequency: daily
+- Freshness target: 24 hours
+- Availability: 99.5 %
+
+## Classification Rationale
+
+This product contains no PII and no commercially sensitive figures at a granularity
+that would constitute trade-secret information. `internal` classification is appropriate:
+any authenticated domain team can subscribe without additional approval.
+
+## Sources
+
+- `ads-platform-api` → `/campaigns/metrics/daily`
+
+## Catalog
+
+Discover this product:
+```bash
+datameshy catalog search --domain marketing
+datameshy catalog describe --name campaign_metrics
+```

--- a/examples/marketing-domain/products/campaign_metrics/glue_jobs/gold_aggregate.py
+++ b/examples/marketing-domain/products/campaign_metrics/glue_jobs/gold_aggregate.py
@@ -1,0 +1,34 @@
+"""
+campaign_metrics — gold aggregate job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Gold (Data Product)
+Purpose: Produce the shareable data product: aggregate daily campaign metrics
+         with conversion_rate computed, partitioned by channel.
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'silver_bucket', 'gold_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read silver Iceberg table from s3://<silver_bucket>/marketing/campaign_metrics/
+# 2. Compute conversion_rate = CAST(clicks AS DOUBLE) / NULLIF(impressions, 0)
+# 3. Aggregate metrics per (campaign_id, channel, date)
+# 4. Write gold product to s3://<gold_bucket>/marketing/campaign_metrics/ as Iceberg
+#    partitioned by channel
+# 5. Register/refresh table in AWS Glue Data Catalog
+# 6. Commit job
+
+# job.commit()

--- a/examples/marketing-domain/products/campaign_metrics/glue_jobs/raw_ingestion.py
+++ b/examples/marketing-domain/products/campaign_metrics/glue_jobs/raw_ingestion.py
@@ -1,0 +1,29 @@
+"""
+campaign_metrics — raw ingestion job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Bronze (Raw)
+Purpose: Ingest raw campaign metrics from source API into S3 raw zone as Iceberg table.
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'source_bucket', 'raw_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read from ads-platform-api source (S3 landing zone or API extract)
+# 2. Write raw records to s3://<raw_bucket>/marketing/campaign_metrics/ as Iceberg
+# 3. Commit job
+
+# job.commit()

--- a/examples/marketing-domain/products/campaign_metrics/glue_jobs/silver_transform.py
+++ b/examples/marketing-domain/products/campaign_metrics/glue_jobs/silver_transform.py
@@ -1,0 +1,31 @@
+"""
+campaign_metrics — silver transform job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Silver (Validated)
+Purpose: Validate, cast types, enforce not-null constraints, and deduplicate raw records.
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'raw_bucket', 'silver_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read raw Iceberg table from s3://<raw_bucket>/marketing/campaign_metrics/
+# 2. Validate: cast spend to decimal(10,2), drop rows where campaign_id is null
+# 3. Deduplicate on (campaign_id, channel, date)
+# 4. Write validated records to s3://<silver_bucket>/marketing/campaign_metrics/ as Iceberg
+# 5. Commit job
+
+# job.commit()

--- a/examples/marketing-domain/products/campaign_metrics/product.yaml
+++ b/examples/marketing-domain/products/campaign_metrics/product.yaml
@@ -1,0 +1,75 @@
+# product.yaml — campaign_metrics data product
+# Domain: marketing
+# Schema version: 1
+
+product:
+  name: campaign_metrics
+  domain: marketing
+  description: "Daily aggregated campaign performance metrics by channel"
+  owner: marketing-data-team@company.com
+  contact_channel: "#marketing-data-support"
+
+schema_version: 1
+
+schema:
+  format: iceberg
+  columns:
+    - name: campaign_id
+      type: string
+      description: "Unique campaign identifier"
+      pii: false
+      nullable: false
+    - name: channel
+      type: string
+      description: "Marketing channel (e.g. email, paid-search, social)"
+      pii: false
+      nullable: true
+    - name: impressions
+      type: long
+      description: "Total ad impressions for the campaign on the given day"
+      pii: false
+      nullable: true
+    - name: clicks
+      type: long
+      description: "Total clicks on the campaign on the given day"
+      pii: false
+      nullable: true
+    - name: spend
+      type: "decimal(10,2)"
+      description: "Total spend in USD for the campaign on the given day"
+      pii: false
+      nullable: true
+    - name: conversion_rate
+      type: double
+      description: "Clicks-to-conversion ratio for the day"
+      pii: false
+      nullable: true
+  partition_by:
+    - column: channel
+      transform: identity
+
+quality:
+  rules:
+    - name: campaign_id_complete
+      rule: "IsComplete 'campaign_id'"
+      threshold: 1.0
+    - name: spend_positive
+      rule: "ColumnValues 'spend' > 0"
+  minimum_quality_score: 95
+
+sla:
+  refresh_frequency: daily
+  freshness_target: "24 hours"
+  availability: "99.5%"
+
+tags:
+  - marketing
+  - campaign
+  - performance
+
+classification: internal
+
+lineage:
+  sources:
+    - system: "ads-platform-api"
+      endpoint: "/campaigns/metrics/daily"

--- a/examples/sales-domain/README.md
+++ b/examples/sales-domain/README.md
@@ -1,0 +1,34 @@
+# Sales Domain — Example Data Products
+
+This directory contains example data products for the **sales** domain.
+
+## Products
+
+| Product | Schema Version | Status | Description |
+|---|---|---|---|
+| [revenue_daily_v1](products/revenue_daily_v1/) | 1 | DEPRECATED (sunset 2026-09-01) | Daily revenue by region and product line (original schema) |
+| [revenue_daily_v2](products/revenue_daily_v2/) | 2 | ACTIVE | Daily revenue with gross/net split (breaking change from v1) |
+
+## Schema versioning story
+
+`revenue_daily_v1` and `revenue_daily_v2` illustrate Data Meshy's versioned coexistence
+pattern (ADR-009):
+
+- A breaking schema change (renaming `revenue` → `gross_revenue`) required a new product
+  version rather than an in-place mutation.
+- Both versions live simultaneously in the catalog so existing consumers are not forced
+  to migrate immediately.
+- `revenue_daily_v1` is marked `deprecated: true` with `sunset_date: 2026-09-01`.
+  The authoritative DEPRECATED status is managed in DynamoDB by the `product deprecate` CLI.
+- After the sunset date, `revenue_daily_v1` will be RETIRED: Lake Formation grants revoked,
+  resource links deleted.
+
+Consumers should migrate to `revenue_daily_v2` before 2026-09-01. See
+[revenue_daily_v1/README.md](products/revenue_daily_v1/README.md) for the migration guide.
+
+## Browsing the catalog
+
+```bash
+datameshy catalog search --domain sales
+datameshy catalog describe --name revenue_daily_v2
+```

--- a/examples/sales-domain/products/revenue_daily_v1/README.md
+++ b/examples/sales-domain/products/revenue_daily_v1/README.md
@@ -1,0 +1,60 @@
+# revenue_daily_v1
+
+**Domain**: sales
+**Schema version**: 1
+**Classification**: internal
+**Status**: DEPRECATED
+**Sunset date**: 2026-09-01
+**Superseded by**: [revenue_daily_v2](../revenue_daily_v2/README.md)
+
+> **DEPRECATED** — This product will be retired on 2026-09-01.
+> Existing queries continue to work until then, but no new subscriptions are accepted.
+> Migrate to `revenue_daily_v2` before the sunset date.
+
+## Overview
+
+Daily revenue aggregated by region and product line (schema version 1).
+This was the original revenue data product for the sales domain.
+
+## Schema
+
+| Column | Type | Nullable | Description |
+|---|---|---|---|
+| date | date | NOT NULL | Reporting date |
+| region | string | yes | Sales region |
+| product_line | string | yes | Product line name |
+| revenue | decimal(12,2) | yes | Total revenue in USD |
+| units_sold | long | yes | Total units sold |
+
+Partition key: `date` (month transform).
+
+## Why it is deprecated
+
+A breaking schema change was required to distinguish gross revenue from net revenue
+(after discounts and returns). In v2, the `revenue` column was renamed to `gross_revenue`
+and a new `net_revenue` column was added.
+
+Because renaming a column is a breaking change (consumers referencing `revenue` by name
+will fail on the new schema), a new product version (`revenue_daily_v2`) was created
+rather than mutating the existing schema in place — following ADR-009 (versioned
+coexistence).
+
+## Migration path to v2
+
+1. Update your query or ETL job to use `revenue_daily_v2` instead of `revenue_daily_v1`.
+2. Replace any reference to the `revenue` column with `gross_revenue`.
+3. Optionally consume `net_revenue` for post-discount/post-return figures.
+4. Subscribe to `revenue_daily_v2` via the catalog:
+   ```bash
+   datameshy catalog describe --name revenue_daily_v2
+   ```
+5. Cancel your subscription to `revenue_daily_v1` after validating the new pipeline.
+
+## Quality Rules
+
+- `date` must be complete (no nulls) — threshold 100 %
+- `revenue` must be positive (> 0)
+
+## Sources
+
+- `sales-warehouse` → `public.daily_revenue`

--- a/examples/sales-domain/products/revenue_daily_v1/glue_jobs/gold_aggregate.py
+++ b/examples/sales-domain/products/revenue_daily_v1/glue_jobs/gold_aggregate.py
@@ -1,0 +1,35 @@
+"""
+revenue_daily_v1 — gold aggregate job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Gold (Data Product)
+Purpose: Produce the shareable v1 data product: daily revenue by region and product line.
+
+NOTE: This product is deprecated. Sunset date: 2026-09-01.
+      Migrate consumers to revenue_daily_v2 (column 'revenue' renamed to 'gross_revenue').
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'silver_bucket', 'gold_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read silver Iceberg table from s3://<silver_bucket>/sales/revenue_daily_v1/
+# 2. Aggregate: SUM(revenue) per (date, region, product_line)
+# 3. Write gold product to s3://<gold_bucket>/sales/revenue_daily_v1/ as Iceberg
+#    partitioned by date (month)
+# 4. Register/refresh table in AWS Glue Data Catalog
+# 5. Commit job
+
+# job.commit()

--- a/examples/sales-domain/products/revenue_daily_v1/glue_jobs/raw_ingestion.py
+++ b/examples/sales-domain/products/revenue_daily_v1/glue_jobs/raw_ingestion.py
@@ -1,0 +1,31 @@
+"""
+revenue_daily_v1 — raw ingestion job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Bronze (Raw)
+Purpose: Ingest raw daily revenue records from source warehouse into S3 raw zone.
+
+NOTE: This product is deprecated. New pipelines should target revenue_daily_v2.
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'source_bucket', 'raw_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read from sales-warehouse source (S3 landing zone or JDBC extract)
+# 2. Write raw records to s3://<raw_bucket>/sales/revenue_daily_v1/ as Iceberg
+# 3. Commit job
+
+# job.commit()

--- a/examples/sales-domain/products/revenue_daily_v1/glue_jobs/silver_transform.py
+++ b/examples/sales-domain/products/revenue_daily_v1/glue_jobs/silver_transform.py
@@ -1,0 +1,33 @@
+"""
+revenue_daily_v1 — silver transform job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Silver (Validated)
+Purpose: Validate and cleanse raw revenue records; enforce not-null on date column.
+
+NOTE: This product is deprecated. New pipelines should target revenue_daily_v2.
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'raw_bucket', 'silver_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read raw Iceberg table from s3://<raw_bucket>/sales/revenue_daily_v1/
+# 2. Validate: cast revenue to decimal(12,2), drop rows where date is null
+# 3. Deduplicate on (date, region, product_line)
+# 4. Write validated records to s3://<silver_bucket>/sales/revenue_daily_v1/ as Iceberg
+# 5. Commit job
+
+# job.commit()

--- a/examples/sales-domain/products/revenue_daily_v1/product.yaml
+++ b/examples/sales-domain/products/revenue_daily_v1/product.yaml
@@ -1,0 +1,75 @@
+# product.yaml — revenue_daily_v1 data product
+# Domain: sales
+# Schema version: 1
+# DEPRECATED: superseded by revenue_daily_v2 (breaking rename: revenue -> gross_revenue)
+
+product:
+  name: revenue_daily_v1
+  domain: sales
+  description: "Daily revenue aggregated by region and product line (v1 — deprecated)"
+  owner: sales-data-team@company.com
+  contact_channel: "#sales-data-support"
+
+schema_version: 1
+
+deprecated: true
+sunset_date: "2026-09-01"
+superseded_by: revenue_daily_v2
+
+schema:
+  format: iceberg
+  columns:
+    - name: date
+      type: date
+      description: "Reporting date"
+      pii: false
+      nullable: false
+    - name: region
+      type: string
+      description: "Sales region"
+      pii: false
+      nullable: true
+    - name: product_line
+      type: string
+      description: "Product line name"
+      pii: false
+      nullable: true
+    - name: revenue
+      type: "decimal(12,2)"
+      description: "Total revenue in USD (deprecated column — use gross_revenue in v2)"
+      pii: false
+      nullable: true
+    - name: units_sold
+      type: long
+      description: "Total units sold"
+      pii: false
+      nullable: true
+  partition_by:
+    - column: date
+      transform: month
+
+quality:
+  rules:
+    - name: date_complete
+      rule: "IsComplete 'date'"
+      threshold: 1.0
+    - name: revenue_positive
+      rule: "ColumnValues 'revenue' > 0"
+  minimum_quality_score: 95
+
+sla:
+  refresh_frequency: daily
+  freshness_target: "24 hours"
+  availability: "99.5%"
+
+tags:
+  - sales
+  - revenue
+  - deprecated
+
+classification: internal
+
+lineage:
+  sources:
+    - system: "sales-warehouse"
+      table: "public.daily_revenue"

--- a/examples/sales-domain/products/revenue_daily_v2/README.md
+++ b/examples/sales-domain/products/revenue_daily_v2/README.md
@@ -1,0 +1,66 @@
+# revenue_daily_v2
+
+**Domain**: sales
+**Schema version**: 2
+**Classification**: internal
+**Status**: ACTIVE
+**Replaces**: [revenue_daily_v1](../revenue_daily_v1/README.md) (deprecated, sunset 2026-09-01)
+
+## Overview
+
+Daily revenue aggregated by region and product line — schema version 2.
+This product introduces clearer revenue semantics by separating gross revenue
+from net revenue (after discounts and returns).
+
+## Schema
+
+| Column | Type | Nullable | Description |
+|---|---|---|---|
+| date | date | NOT NULL | Reporting date |
+| region | string | yes | Sales region |
+| product_line | string | yes | Product line name |
+| gross_revenue | decimal(12,2) | yes | Total gross revenue in USD |
+| units_sold | long | yes | Total units sold |
+| net_revenue | decimal(12,2) | yes | Net revenue after discounts and returns (new in v2) |
+
+Partition key: `date` (month transform).
+
+## Breaking changes from v1
+
+| Change | v1 column | v2 column | Impact |
+|---|---|---|---|
+| Column renamed | `revenue` | `gross_revenue` | **Breaking** — queries referencing `revenue` by name will fail |
+| New column | — | `net_revenue` | Additive — existing SELECT * queries receive an extra column |
+
+Because the rename is a breaking change, v1 and v2 coexist simultaneously in the catalog
+(ADR-009). Consumers choose their migration timing. v1 is deprecated and will be retired
+on 2026-09-01.
+
+## Quality Rules
+
+- `date` must be complete (no nulls) — threshold 100 %
+- `gross_revenue` must be positive (> 0)
+- `net_revenue` must be positive (> 0)
+
+## SLA
+
+- Refresh frequency: daily
+- Freshness target: 24 hours
+- Availability: 99.5 %
+
+## Sources
+
+- `sales-warehouse` → `public.daily_revenue`
+- `returns-service` → `/returns/daily-summary`
+
+## Catalog
+
+```bash
+datameshy catalog search --domain sales
+datameshy catalog describe --name revenue_daily_v2
+```
+
+> Note: `datameshy catalog search --domain sales` returns both `revenue_daily_v1` and
+> `revenue_daily_v2`. This is expected — both are live in the catalog until v1 is retired.
+> Integration-level validation of the catalog search results requires a live DynamoDB
+> instance and is not covered by the local spec validation script.

--- a/examples/sales-domain/products/revenue_daily_v2/glue_jobs/gold_aggregate.py
+++ b/examples/sales-domain/products/revenue_daily_v2/glue_jobs/gold_aggregate.py
@@ -1,0 +1,37 @@
+"""
+revenue_daily_v2 — gold aggregate job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Gold (Data Product)
+Purpose: Produce the shareable v2 data product: daily revenue by region and product line
+         with both gross_revenue and net_revenue columns.
+
+Breaking changes from v1:
+  - Column 'revenue' renamed to 'gross_revenue'
+  - New column 'net_revenue' added
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'silver_bucket', 'gold_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read silver Iceberg table from s3://<silver_bucket>/sales/revenue_daily_v2/
+# 2. Aggregate: SUM(gross_revenue), SUM(net_revenue), SUM(units_sold) per (date, region, product_line)
+# 3. Write gold product to s3://<gold_bucket>/sales/revenue_daily_v2/ as Iceberg
+#    partitioned by date (month)
+# 4. Register/refresh table in AWS Glue Data Catalog
+# 5. Commit job
+
+# job.commit()

--- a/examples/sales-domain/products/revenue_daily_v2/glue_jobs/raw_ingestion.py
+++ b/examples/sales-domain/products/revenue_daily_v2/glue_jobs/raw_ingestion.py
@@ -1,0 +1,31 @@
+"""
+revenue_daily_v2 — raw ingestion job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Bronze (Raw)
+Purpose: Ingest raw daily revenue records from source warehouse into S3 raw zone.
+         v2 adds net_revenue sourced from the returns-service.
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'source_bucket', 'raw_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read from sales-warehouse source (S3 landing zone or JDBC extract)
+# 2. Join with returns-service daily summary to compute net_revenue
+# 3. Write raw records to s3://<raw_bucket>/sales/revenue_daily_v2/ as Iceberg
+# 4. Commit job
+
+# job.commit()

--- a/examples/sales-domain/products/revenue_daily_v2/glue_jobs/silver_transform.py
+++ b/examples/sales-domain/products/revenue_daily_v2/glue_jobs/silver_transform.py
@@ -1,0 +1,32 @@
+"""
+revenue_daily_v2 — silver transform job stub.
+Replace with real PySpark logic when deploying.
+
+Layer: Silver (Validated)
+Purpose: Validate and cleanse raw revenue records for v2 schema.
+         Breaking change vs v1: column name is 'gross_revenue' (not 'revenue').
+"""
+
+# Standard imports for AWS Glue PySpark jobs
+# import sys
+# from awsglue.transforms import *
+# from awsglue.utils import getResolvedOptions
+# from pyspark.context import SparkContext
+# from awsglue.context import GlueContext
+# from awsglue.job import Job
+
+# args = getResolvedOptions(sys.argv, ['JOB_NAME', 'raw_bucket', 'silver_bucket'])
+# sc = SparkContext()
+# glueContext = GlueContext(sc)
+# spark = glueContext.spark_session
+# job = Job(glueContext)
+# job.init(args['JOB_NAME'], args)
+
+# TODO: implement
+# 1. Read raw Iceberg table from s3://<raw_bucket>/sales/revenue_daily_v2/
+# 2. Validate: cast gross_revenue and net_revenue to decimal(12,2), drop rows where date is null
+# 3. Deduplicate on (date, region, product_line)
+# 4. Write validated records to s3://<silver_bucket>/sales/revenue_daily_v2/ as Iceberg
+# 5. Commit job
+
+# job.commit()

--- a/examples/sales-domain/products/revenue_daily_v2/product.yaml
+++ b/examples/sales-domain/products/revenue_daily_v2/product.yaml
@@ -1,0 +1,79 @@
+# product.yaml — revenue_daily_v2 data product
+# Domain: sales
+# Schema version: 2
+# Breaking change from v1: 'revenue' renamed to 'gross_revenue'; 'net_revenue' added
+
+product:
+  name: revenue_daily_v2
+  domain: sales
+  description: "Daily revenue aggregated by region and product line (v2 — breaking schema change from v1)"
+  owner: sales-data-team@company.com
+  contact_channel: "#sales-data-support"
+
+schema_version: 2
+
+schema:
+  format: iceberg
+  columns:
+    - name: date
+      type: date
+      description: "Reporting date"
+      pii: false
+      nullable: false
+    - name: region
+      type: string
+      description: "Sales region"
+      pii: false
+      nullable: true
+    - name: product_line
+      type: string
+      description: "Product line name"
+      pii: false
+      nullable: true
+    - name: gross_revenue
+      type: "decimal(12,2)"
+      description: "Total gross revenue in USD (renamed from 'revenue' in v1)"
+      pii: false
+      nullable: true
+    - name: units_sold
+      type: long
+      description: "Total units sold"
+      pii: false
+      nullable: true
+    - name: net_revenue
+      type: "decimal(12,2)"
+      description: "Net revenue after discounts and returns (new in v2)"
+      pii: false
+      nullable: true
+  partition_by:
+    - column: date
+      transform: month
+
+quality:
+  rules:
+    - name: date_complete
+      rule: "IsComplete 'date'"
+      threshold: 1.0
+    - name: gross_revenue_positive
+      rule: "ColumnValues 'gross_revenue' > 0"
+    - name: net_revenue_positive
+      rule: "ColumnValues 'net_revenue' > 0"
+  minimum_quality_score: 95
+
+sla:
+  refresh_frequency: daily
+  freshness_target: "24 hours"
+  availability: "99.5%"
+
+tags:
+  - sales
+  - revenue
+
+classification: internal
+
+lineage:
+  sources:
+    - system: "sales-warehouse"
+      table: "public.daily_revenue"
+    - system: "returns-service"
+      endpoint: "/returns/daily-summary"


### PR DESCRIPTION
## Summary

- Adds `examples/marketing-domain/products/campaign_metrics/` — schema v1, 6 columns, no PII, `classification: internal`
- Adds `examples/sales-domain/products/revenue_daily_v1/` — schema v1, marked `deprecated: true` with `sunset_date: 2026-09-01` and `superseded_by: revenue_daily_v2`
- Adds `examples/sales-domain/products/revenue_daily_v2/` — schema v2 with breaking change (`revenue` renamed to `gross_revenue`, `net_revenue` added)
- Glue job stubs (`raw_ingestion.py`, `silver_transform.py`, `gold_aggregate.py`) for all three products
- READMEs explaining the schema version story and deprecation/migration guidance for each product

These serve as canonical reference implementations for domain teams and exercise the catalog CLI (search/browse/describe) end-to-end.

## ADR alignment

Implements the versioned coexistence pattern from ADR-009: v1 and v2 live side-by-side in the catalog; consumers migrate on their own timeline before the v1 sunset date.

## Acceptance criteria (issue #16)

- [x] `campaign_metrics/product.yaml` — schema v1, no PII, `classification: internal`
- [x] `revenue_daily_v1/product.yaml` — schema v1, `deprecated: true`, `sunset_date`, `superseded_by`
- [x] `revenue_daily_v2/product.yaml` — schema v2, breaking change: `revenue` → `gross_revenue` + `net_revenue` added
- [x] Glue job stubs for all three products (9 files)
- [x] READMEs for each product + domain-level READMEs
- [x] Local spec validation passes (required keys + quality rule column refs verified)
- [ ] `datameshy catalog search` integration checks — require live DynamoDB (documented in READMEs)

## Security review

No CRITICAL or HIGH findings. PII classification verified correct across all specs.

## Test plan

- [ ] CI `product-validate` workflow passes on this PR
- [ ] Confirm `campaign_metrics`, `revenue_daily_v1`, `revenue_daily_v2` appear in catalog after `product publish` against a dev environment
- [ ] `datameshy catalog describe sales/revenue_daily_v1` shows `status: deprecated` with sunset date

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)