### PR TITLE
Phase 4 Stream 1: foundations

### DIFF
--- a/.github/workflows/reusable-product-validate.yml
+++ b/.github/workflows/reusable-product-validate.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install datameshy CLI
-        run: pip install datameshy
+      - name: Install validation dependencies
+        run: pip install jsonschema pyyaml
 
       - name: Find and validate all product.yaml files
         run: |
@@ -35,12 +35,29 @@ jobs:
             exit 0
           fi
 
+          SCHEMA="schemas/product_spec.json"
+
           for spec in $SPECS; do
             echo "Validating: $spec"
-            if datameshy product validate --spec "$spec"; then
-              echo "  VALID: $spec"
-            else
-              echo "  INVALID: $spec"
+            python - "$spec" "$SCHEMA" <<'PYEOF'
+          import json, sys, yaml
+          from jsonschema import validate, ValidationError
+
+          spec_path, schema_path = sys.argv[1], sys.argv[2]
+
+          with open(schema_path) as f:
+              schema = json.load(f)
+          with open(spec_path) as f:
+              data = yaml.safe_load(f)
+
+          try:
+              validate(instance=data, schema=schema)
+              print(f"  VALID: {spec_path}")
+          except ValidationError as e:
+              print(f"  INVALID: {spec_path} — {e.message}")
+              sys.exit(1)
+          PYEOF
+            if [ $? -ne 0 ]; then
               FAIL=1
             fi
           done

--- a/.github/workflows/validate-domains.yml
+++ b/.github/workflows/validate-domains.yml
@@ -1,0 +1,64 @@
+name: Validate Domain Registry
+
+on:
+  push:
+    paths:
+      - "domains/**"
+  pull_request:
+    paths:
+      - "domains/**"
+
+jobs:
+  validate:
+    name: Validate domains/*.yaml against schema
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Install validation dependencies
+        run: pip install jsonschema pyyaml
+
+      - name: Validate all domain registry files
+        run: |
+          FAIL=0
+          SCHEMA="schemas/domain.json"
+          DOMAINS=$(find domains/ -name "*.yaml" -not -name "example.yaml" 2>/dev/null || true)
+
+          if [ -z "$DOMAINS" ]; then
+            echo "No domain registry files found in domains/ — nothing to validate."
+            exit 0
+          fi
+
+          for domain_file in $DOMAINS; do
+            echo "Validating: $domain_file"
+            python - "$domain_file" "$SCHEMA" <<'PYEOF'
+          import json, sys, yaml
+          from jsonschema import validate, ValidationError
+
+          domain_path, schema_path = sys.argv[1], sys.argv[2]
+
+          with open(schema_path) as f:
+              schema = json.load(f)
+          with open(domain_path) as f:
+              data = yaml.safe_load(f)
+
+          try:
+              validate(instance=data, schema=schema)
+              print(f"  VALID: {domain_path}")
+          except ValidationError as e:
+              print(f"  INVALID: {domain_path} — {e.message}")
+              sys.exit(1)
+          PYEOF
+            if [ $? -ne 0 ]; then
+              FAIL=1
+            fi
+          done
+
+          exit $FAIL

--- a/domains/example.yaml
+++ b/domains/example.yaml
@@ -1,0 +1,28 @@
+# domains/example.yaml
+# Reference file for the domain registry format.
+# Copy this file to domains/{your_domain_name}.yaml and fill in all fields.
+# All fields are required. See schemas/domain.json for validation rules.
+
+# Unique domain identifier: snake_case, matches the filename (without .yaml).
+# Pattern: ^[a-z][a-z0-9_]*$
+domain_name: example_domain
+
+# AWS account ID for this domain (12 digits, no hyphens).
+account_id: "123456789012"
+
+# AWS region where domain infrastructure is deployed.
+# Pattern: <area>-<direction>-<number> e.g. ap-southeast-2, us-east-1
+aws_region: ap-southeast-2
+
+# Email address of the domain owner or on-call group.
+owner_email: domain-owner@example.com
+
+# Full GitHub repository slug (org/repo) for this domain's data product repo.
+github_repo: your-org/example-domain-data
+
+# Glob pattern used by platform CI workflows to locate this domain's product repos.
+# Typical value is identical to github_repo for single-repo domains.
+repo_pattern: your-org/example-domain-*
+
+# ISO 8601 date when this domain was onboarded to the mesh (YYYY-MM-DD).
+onboarded_at: "2026-01-01"

--- a/schemas/domain.json
+++ b/schemas/domain.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/data-meshy/schemas/domain.json",
+  "title": "DataMeshy Domain Registry Entry",
+  "description": "JSON Schema (Draft 7) for validating domains/*.yaml registry files. Each file represents one onboarded domain.",
+  "type": "object",
+  "required": [
+    "domain_name",
+    "account_id",
+    "aws_region",
+    "owner_email",
+    "github_repo",
+    "repo_pattern",
+    "onboarded_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "domain_name": {
+      "description": "Unique domain identifier (snake_case). Must match the filename (domains/{domain_name}.yaml).",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "account_id": {
+      "description": "AWS account ID for this domain (12-digit string).",
+      "type": "string",
+      "pattern": "^[0-9]{12}$"
+    },
+    "aws_region": {
+      "description": "AWS region where this domain's infrastructure is deployed (e.g., ap-southeast-2).",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z]{2}-[a-z]+-[0-9]$"
+    },
+    "owner_email": {
+      "description": "Email address of the domain owner or on-call team.",
+      "type": "string",
+      "format": "email"
+    },
+    "github_repo": {
+      "description": "Full GitHub repository slug for the domain repo (org/repo).",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
+    "repo_pattern": {
+      "description": "Glob pattern used by platform workflows to locate domain product repos.",
+      "type": "string",
+      "minLength": 1
+    },
+    "onboarded_at": {
+      "description": "ISO 8601 date when the domain was onboarded to the mesh (YYYY-MM-DD).",
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes `reusable-product-validate.yml` to remove the broken `pip install datameshy` dependency, replacing it with inline Python using `jsonschema` directly against `schemas/product_spec.json`
- Adds the `domains/` registry: JSON schema (`schemas/domain.json`), reference file (`domains/example.yaml`), and CI workflow (`validate-domains.yml`) that validates all domain entries on every PR touching `domains/`

closes #20, closes #21

## Acceptance criteria covered

**#20:**
- [x] `reusable-product-validate.yml` no longer references `pip install datameshy`
- [x] Validation uses `jsonschema` directly against `schemas/product_spec.json`
- [x] `workflow_call` interface unchanged (`products_dir` input, default `products/`)
- [x] `product-spec-validate.yml` caller unchanged — still works

**#21:**
- [x] `domains/` directory exists at repo root
- [x] `schemas/domain.json` enforces all 7 required fields
- [x] `domains/example.yaml` with inline comments as reference
- [x] `validate-domains.yml` triggers on `push`/`pull_request` when `domains/**` changes
- [x] Malformed domain files fail with a clear error message (tested locally)

## Test plan

- [ ] Confirm `validate-domains.yml` triggers on a PR that changes `domains/*.yaml`
- [ ] Confirm `reusable-product-validate.yml` job passes on a PR with a valid `product.yaml`
- [ ] Confirm `reusable-product-validate.yml` job fails on a PR with an invalid `product.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)