### PR TITLE
Phase 6 Stream 1: Lambda deployment Terraform — all 14 handlers wired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 .pytest_cache/
 .coverage
 htmlcov/
+
+# Terraform Lambda build artifacts
+infra/modules/governance/.build/

--- a/infra/environments/central/.terraform.lock.hcl
+++ b/infra/environments/central/.terraform.lock.hcl
@@ -1,0 +1,66 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.8.0"
+  hashes = [
+    "h1:i4jOdktQW0SDbjM3IC2ZSqdd881FzVY+V11XKkLPHrk=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 5.30.0, ~> 5.40"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/environments/central/main.tf
+++ b/infra/environments/central/main.tf
@@ -138,11 +138,9 @@ module "governance" {
   datazone_domain_name = var.datazone_domain_name
   datazone_sso_type    = var.datazone_sso_type
 
-  # Phase 2: Subscription API Lambda ARNs (placeholders until Stream 2 merges)
-  subscription_provisioner_lambda_arn = var.subscription_provisioner_lambda_arn
-  subscription_compensator_lambda_arn = var.subscription_compensator_lambda_arn
-  subscription_approver_lambda_arn    = var.subscription_approver_lambda_arn
-  subscription_lister_lambda_arn      = var.subscription_lister_lambda_arn
+  # Phase 6: Lambda ARN variable passthrough removed — lambdas.tf in the
+  # governance module now creates all Lambdas directly. The variable declarations
+  # above are retained for backward compatibility with existing tfvars files.
 }
 
 ###############################################################################
@@ -313,10 +311,11 @@ output "datazone_portal_url" {
 }
 
 ###############################################################################
-# Phase 2: Subscription module instantiation
-# Lambda ARN variables default to "" until Stream 2 merges.
-# The SFN is created with placeholder Lambda ARNs — it will work structurally
-# but execution requires real Lambdas from Stream 2.
+# Phase 6: Subscription module instantiation
+# Lambda ARNs now come from module.governance outputs (Phase 6 Stream 1).
+# The "" placeholder variables for provisioner/compensator are no longer used
+# for the subscription module — they are kept in variable declarations above
+# for backward compatibility but are not passed through.
 ###############################################################################
 
 module "subscription" {
@@ -328,9 +327,9 @@ module "subscription" {
 
   central_event_bus_arn = module.governance.central_event_bus_arn
 
-  # Lambda ARNs — populated after Stream 2 merges
-  provisioner_lambda_arn = var.subscription_provisioner_lambda_arn
-  compensator_lambda_arn = var.subscription_compensator_lambda_arn
+  # Lambda ARNs — wired from governance module outputs (Phase 6 Stream 1)
+  provisioner_lambda_arn = module.governance.subscription_provisioner_lambda_arn
+  compensator_lambda_arn = module.governance.subscription_compensator_lambda_arn
 
   # IAM roles from governance module (shared contract)
   lf_grantor_role_arn  = module.governance.mesh_lf_grantor_role_arn

--- a/infra/modules/governance/api_gateway.tf
+++ b/infra/modules/governance/api_gateway.tf
@@ -87,122 +87,105 @@ resource "aws_cloudwatch_log_group" "mesh_api_access_logs" {
 ###############################################################################
 
 ###############################################################################
-# Lambda integrations
-# When Stream 2 merges, the *_lambda_arn variables are populated.
-# Until then, routes exist but integrations point to empty ARNs which APIGW
-# will reject at invocation time (not at plan/apply time).
-# Use count/for_each guard so integration resources are skipped when ARN is "".
+# Lambda integrations — Phase 6: all Lambdas now exist in lambdas.tf.
+# Integration URIs reference aws_lambda_function resources directly.
+# Variable-based count guards removed; resources are unconditional.
 ###############################################################################
 
 resource "aws_apigatewayv2_integration" "subscription_create" {
-  count = var.subscription_provisioner_lambda_arn != "" ? 1 : 0
-
   api_id                 = aws_apigatewayv2_api.mesh_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = var.subscription_provisioner_lambda_arn
+  integration_uri        = aws_lambda_function.subscription_request.arn
   integration_method     = "POST"
   payload_format_version = "2.0"
   timeout_milliseconds   = 29000
-  description            = "Subscription create handler (Stream 2: subscription_create Lambda)"
+  description            = "Subscription create handler (subscription_request Lambda)"
 }
 
 resource "aws_apigatewayv2_integration" "subscription_list" {
-  count = var.subscription_lister_lambda_arn != "" ? 1 : 0
-
   api_id                 = aws_apigatewayv2_api.mesh_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = var.subscription_lister_lambda_arn
+  integration_uri        = aws_lambda_function.subscription_request.arn
   integration_method     = "POST"
   payload_format_version = "2.0"
   timeout_milliseconds   = 29000
-  description            = "Subscription list handler (Stream 2: subscription_list Lambda)"
+  description            = "Subscription list handler (subscription_request Lambda — list path)"
 }
 
 resource "aws_apigatewayv2_integration" "subscription_approve" {
-  count = var.subscription_approver_lambda_arn != "" ? 1 : 0
-
   api_id                 = aws_apigatewayv2_api.mesh_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = var.subscription_approver_lambda_arn
+  integration_uri        = aws_lambda_function.subscription_request.arn
   integration_method     = "POST"
   payload_format_version = "2.0"
   timeout_milliseconds   = 29000
-  description            = "Subscription approve/revoke handler (Stream 2: subscription_approver Lambda)"
+  description            = "Subscription approve/revoke handler (subscription_request Lambda — approve/revoke path)"
 }
 
 ###############################################################################
 # Routes — AWS_IAM auth on all routes
-# Routes are created unconditionally so the API structure exists from day 1.
-# Integrations are conditional (above); routes without integrations return 404.
 ###############################################################################
 
 resource "aws_apigatewayv2_route" "post_subscriptions" {
   api_id             = aws_apigatewayv2_api.mesh_api.id
   route_key          = "POST /subscriptions"
   authorization_type = "AWS_IAM"
-  target             = length(aws_apigatewayv2_integration.subscription_create) > 0 ? "integrations/${aws_apigatewayv2_integration.subscription_create[0].id}" : null
+  target             = "integrations/${aws_apigatewayv2_integration.subscription_create.id}"
 }
 
 resource "aws_apigatewayv2_route" "get_subscriptions" {
   api_id             = aws_apigatewayv2_api.mesh_api.id
   route_key          = "GET /subscriptions"
   authorization_type = "AWS_IAM"
-  target             = length(aws_apigatewayv2_integration.subscription_list) > 0 ? "integrations/${aws_apigatewayv2_integration.subscription_list[0].id}" : null
+  target             = "integrations/${aws_apigatewayv2_integration.subscription_list.id}"
 }
 
 resource "aws_apigatewayv2_route" "post_subscription_approve" {
   api_id             = aws_apigatewayv2_api.mesh_api.id
   route_key          = "POST /subscriptions/{id}/approve"
   authorization_type = "AWS_IAM"
-  target             = length(aws_apigatewayv2_integration.subscription_approve) > 0 ? "integrations/${aws_apigatewayv2_integration.subscription_approve[0].id}" : null
+  target             = "integrations/${aws_apigatewayv2_integration.subscription_approve.id}"
 }
 
 resource "aws_apigatewayv2_route" "post_subscription_revoke" {
   api_id             = aws_apigatewayv2_api.mesh_api.id
   route_key          = "POST /subscriptions/{id}/revoke"
   authorization_type = "AWS_IAM"
-  target             = length(aws_apigatewayv2_integration.subscription_approve) > 0 ? "integrations/${aws_apigatewayv2_integration.subscription_approve[0].id}" : null
+  target             = "integrations/${aws_apigatewayv2_integration.subscription_approve.id}"
 }
 
 ###############################################################################
-# Catalog Lambda integrations (Phase 3 Stream 1)
-# catalog_search_lambda_arn and catalog_browse_lambda_arn added in variables.tf
+# Catalog Lambda integrations — direct ARN references (Phase 6)
 ###############################################################################
 
 resource "aws_apigatewayv2_integration" "catalog_search" {
-  count = var.catalog_search_lambda_arn != "" ? 1 : 0
-
   api_id                 = aws_apigatewayv2_api.mesh_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = var.catalog_search_lambda_arn
+  integration_uri        = aws_lambda_function.catalog_search.arn
   integration_method     = "POST"
   payload_format_version = "2.0"
   timeout_milliseconds   = 29000
-  description            = "Catalog search handler (Phase 3 Stream 1: catalog_search Lambda)"
+  description            = "Catalog search handler (catalog_search Lambda)"
 }
 
 resource "aws_apigatewayv2_integration" "catalog_browse" {
-  count = var.catalog_browse_lambda_arn != "" ? 1 : 0
-
   api_id                 = aws_apigatewayv2_api.mesh_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = var.catalog_browse_lambda_arn
+  integration_uri        = aws_lambda_function.catalog_browse.arn
   integration_method     = "POST"
   payload_format_version = "2.0"
   timeout_milliseconds   = 29000
-  description            = "Catalog browse handler (Phase 3 Stream 1: catalog_browse Lambda)"
+  description            = "Catalog browse handler (catalog_browse Lambda)"
 }
 
 resource "aws_apigatewayv2_integration" "catalog_describe" {
-  count = var.catalog_describe_lambda_arn != "" ? 1 : 0
-
   api_id                 = aws_apigatewayv2_api.mesh_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = var.catalog_describe_lambda_arn
+  integration_uri        = aws_lambda_function.catalog_describe.arn
   integration_method     = "POST"
   payload_format_version = "2.0"
   timeout_milliseconds   = 29000
-  description            = "Catalog describe handler (Phase 3 Stream 1: catalog_describe Lambda)"
+  description            = "Catalog describe handler (catalog_describe Lambda)"
 }
 
 ###############################################################################
@@ -213,83 +196,33 @@ resource "aws_apigatewayv2_route" "get_catalog_search" {
   api_id             = aws_apigatewayv2_api.mesh_api.id
   route_key          = "GET /catalog/search"
   authorization_type = "AWS_IAM"
-  target             = length(aws_apigatewayv2_integration.catalog_search) > 0 ? "integrations/${aws_apigatewayv2_integration.catalog_search[0].id}" : null
+  target             = "integrations/${aws_apigatewayv2_integration.catalog_search.id}"
 }
 
 resource "aws_apigatewayv2_route" "get_catalog_browse" {
   api_id             = aws_apigatewayv2_api.mesh_api.id
   route_key          = "GET /catalog/browse"
   authorization_type = "AWS_IAM"
-  target             = length(aws_apigatewayv2_integration.catalog_browse) > 0 ? "integrations/${aws_apigatewayv2_integration.catalog_browse[0].id}" : null
+  target             = "integrations/${aws_apigatewayv2_integration.catalog_browse.id}"
 }
 
 resource "aws_apigatewayv2_route" "get_catalog_describe" {
   api_id             = aws_apigatewayv2_api.mesh_api.id
   route_key          = "GET /catalog/{domain}/{product}"
   authorization_type = "AWS_IAM"
-  target             = length(aws_apigatewayv2_integration.catalog_describe) > 0 ? "integrations/${aws_apigatewayv2_integration.catalog_describe[0].id}" : null
+  target             = "integrations/${aws_apigatewayv2_integration.catalog_describe.id}"
 }
 
 ###############################################################################
 # Lambda permissions — allow APIGW to invoke each Lambda
+# Catalog Lambda permissions are defined in lambdas.tf (apigw_*_direct resources).
+# Subscription Lambda permissions use a wildcard source_arn to cover all routes.
 ###############################################################################
 
-resource "aws_lambda_permission" "apigw_catalog_search" {
-  count = var.catalog_search_lambda_arn != "" ? 1 : 0
-
-  statement_id  = "AllowAPIGWInvokeCatalogSearch"
+resource "aws_lambda_permission" "apigw_subscription_all_routes" {
+  statement_id  = "AllowAPIGWInvokeSubscriptionAllRoutes"
   action        = "lambda:InvokeFunction"
-  function_name = var.catalog_search_lambda_arn
+  function_name = aws_lambda_function.subscription_request.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*/catalog/search"
-}
-
-resource "aws_lambda_permission" "apigw_catalog_browse" {
-  count = var.catalog_browse_lambda_arn != "" ? 1 : 0
-
-  statement_id  = "AllowAPIGWInvokeCatalogBrowse"
-  action        = "lambda:InvokeFunction"
-  function_name = var.catalog_browse_lambda_arn
-  principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*/catalog/browse"
-}
-
-resource "aws_lambda_permission" "apigw_catalog_describe" {
-  count = var.catalog_describe_lambda_arn != "" ? 1 : 0
-
-  statement_id  = "AllowAPIGWInvokeCatalogDescribe"
-  action        = "lambda:InvokeFunction"
-  function_name = var.catalog_describe_lambda_arn
-  principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*/catalog/*/*"
-}
-
-resource "aws_lambda_permission" "apigw_subscription_create" {
-  count = var.subscription_provisioner_lambda_arn != "" ? 1 : 0
-
-  statement_id  = "AllowAPIGWInvokeSubscriptionCreate"
-  action        = "lambda:InvokeFunction"
-  function_name = var.subscription_provisioner_lambda_arn
-  principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*/subscriptions"
-}
-
-resource "aws_lambda_permission" "apigw_subscription_list" {
-  count = var.subscription_lister_lambda_arn != "" ? 1 : 0
-
-  statement_id  = "AllowAPIGWInvokeSubscriptionList"
-  action        = "lambda:InvokeFunction"
-  function_name = var.subscription_lister_lambda_arn
-  principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*/subscriptions"
-}
-
-resource "aws_lambda_permission" "apigw_subscription_approve" {
-  count = var.subscription_approver_lambda_arn != "" ? 1 : 0
-
-  statement_id  = "AllowAPIGWInvokeSubscriptionApprove"
-  action        = "lambda:InvokeFunction"
-  function_name = var.subscription_approver_lambda_arn
-  principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*/subscriptions/*"
+  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*"
 }

--- a/infra/modules/governance/lambdas.tf
+++ b/infra/modules/governance/lambdas.tf
@@ -1,0 +1,1258 @@
+# infra/modules/governance/lambdas.tf
+#
+# All 14 Lambda function resources for the Data Meshy governance plane.
+# Each Lambda has:
+#   - archive_file data source (zips from lambdas/)
+#   - aws_lambda_function (Python 3.12, 256 MB, 30s timeout)
+#   - aws_iam_role execution role with least-privilege inline policy
+#   - aws_cloudwatch_log_group (14-day retention)
+#   - aws_lambda_permission for EventBridge / API GW triggers where applicable
+#
+# Groups:
+#   1. Catalog Lambdas      — catalog_writer, catalog_search, catalog_browse, catalog_describe
+#   2. Subscription Lambdas — subscription_request, subscription_provisioner, subscription_compensator
+#   3. Event handler        — audit_writer, event_validator, freshness_monitor
+#   4. Lifecycle            — product_deprecation, retirement
+#   5. Integration stub     — datazone_connector
+
+###############################################################################
+# Shared trust policy for Lambda execution roles
+###############################################################################
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+###############################################################################
+# ── Section 1: Catalog Lambdas ───────────────────────────────────────────────
+###############################################################################
+
+# ── catalog_writer ────────────────────────────────────────────────────────────
+
+data "archive_file" "catalog_writer" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/catalog_writer.py"
+  output_path = "${path.module}/.build/catalog_writer.zip"
+}
+
+resource "aws_cloudwatch_log_group" "catalog_writer" {
+  name              = "/aws/lambda/mesh-catalog-writer"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "catalog_writer_lambda" {
+  name               = "MeshCatalogWriterLambdaRole"
+  description        = "Execution role for catalog_writer Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "catalog_writer_lambda" {
+  name = "MeshCatalogWriterLambdaPolicy"
+  role = aws_iam_role.catalog_writer_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBWrite"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:GetItem",
+          "dynamodb:Query"
+        ]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_domains.arn,
+          "${aws_dynamodb_table.mesh_domains.arn}/index/*",
+          aws_dynamodb_table.mesh_subscriptions.arn,
+          "${aws_dynamodb_table.mesh_subscriptions.arn}/index/*",
+          aws_dynamodb_table.mesh_quality_scores.arn,
+          "${aws_dynamodb_table.mesh_quality_scores.arn}/index/*",
+          aws_dynamodb_table.mesh_event_dedup.arn
+        ]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [aws_cloudwatch_event_bus.mesh_central.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-catalog-writer:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "catalog_writer" {
+  function_name    = "mesh-catalog-writer"
+  description      = "Handles ProductCreated and ProductRefreshed events — writes to mesh-products and mesh-quality-scores."
+  filename         = data.archive_file.catalog_writer.output_path
+  source_code_hash = data.archive_file.catalog_writer.output_base64sha256
+  handler          = "catalog_writer.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.catalog_writer_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE      = aws_dynamodb_table.mesh_products.name
+      MESH_DOMAINS_TABLE       = aws_dynamodb_table.mesh_domains.name
+      MESH_SUBSCRIPTIONS_TABLE = aws_dynamodb_table.mesh_subscriptions.name
+      MESH_EVENT_DEDUP_TABLE   = aws_dynamodb_table.mesh_event_dedup.name
+      CENTRAL_EVENT_BUS_NAME   = aws_cloudwatch_event_bus.mesh_central.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.catalog_writer]
+
+  tags = local.mandatory_tags
+}
+
+# Allow EventBridge to invoke catalog_writer
+resource "aws_lambda_permission" "eventbridge_catalog_writer" {
+  statement_id  = "AllowEventBridgeInvokeCatalogWriter"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.catalog_writer.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.catalog_update.arn
+}
+
+# ── catalog_search ────────────────────────────────────────────────────────────
+
+data "archive_file" "catalog_search" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/catalog_search.py"
+  output_path = "${path.module}/.build/catalog_search.zip"
+}
+
+resource "aws_cloudwatch_log_group" "catalog_search" {
+  name              = "/aws/lambda/mesh-catalog-search"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "catalog_search_lambda" {
+  name               = "MeshCatalogSearchLambdaRole"
+  description        = "Execution role for catalog_search Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "catalog_search_lambda" {
+  name = "MeshCatalogSearchLambdaPolicy"
+  role = aws_iam_role.catalog_search_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBRead"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_domains.arn,
+          "${aws_dynamodb_table.mesh_domains.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-catalog-search:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "catalog_search" {
+  function_name    = "mesh-catalog-search"
+  description      = "Search products by keyword, domain, tag, and classification."
+  filename         = data.archive_file.catalog_search.output_path
+  source_code_hash = data.archive_file.catalog_search.output_base64sha256
+  handler          = "catalog_search.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.catalog_search_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE = aws_dynamodb_table.mesh_products.name
+      MESH_DOMAINS_TABLE  = aws_dynamodb_table.mesh_domains.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.catalog_search]
+
+  tags = local.mandatory_tags
+}
+
+# ── catalog_browse ────────────────────────────────────────────────────────────
+
+data "archive_file" "catalog_browse" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/catalog_browse.py"
+  output_path = "${path.module}/.build/catalog_browse.zip"
+}
+
+resource "aws_cloudwatch_log_group" "catalog_browse" {
+  name              = "/aws/lambda/mesh-catalog-browse"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "catalog_browse_lambda" {
+  name               = "MeshCatalogBrowseLambdaRole"
+  description        = "Execution role for catalog_browse Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "catalog_browse_lambda" {
+  name = "MeshCatalogBrowseLambdaPolicy"
+  role = aws_iam_role.catalog_browse_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBRead"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_domains.arn,
+          "${aws_dynamodb_table.mesh_domains.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-catalog-browse:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "catalog_browse" {
+  function_name    = "mesh-catalog-browse"
+  description      = "Browse all products grouped by domain."
+  filename         = data.archive_file.catalog_browse.output_path
+  source_code_hash = data.archive_file.catalog_browse.output_base64sha256
+  handler          = "catalog_browse.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.catalog_browse_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE = aws_dynamodb_table.mesh_products.name
+      MESH_DOMAINS_TABLE  = aws_dynamodb_table.mesh_domains.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.catalog_browse]
+
+  tags = local.mandatory_tags
+}
+
+# ── catalog_describe ──────────────────────────────────────────────────────────
+
+data "archive_file" "catalog_describe" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/catalog_describe.py"
+  output_path = "${path.module}/.build/catalog_describe.zip"
+}
+
+resource "aws_cloudwatch_log_group" "catalog_describe" {
+  name              = "/aws/lambda/mesh-catalog-describe"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "catalog_describe_lambda" {
+  name               = "MeshCatalogDescribeLambdaRole"
+  description        = "Execution role for catalog_describe Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "catalog_describe_lambda" {
+  name = "MeshCatalogDescribeLambdaPolicy"
+  role = aws_iam_role.catalog_describe_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBRead"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:Query"]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_domains.arn
+        ]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-catalog-describe:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "catalog_describe" {
+  function_name    = "mesh-catalog-describe"
+  description      = "Describe a specific data product by domain and product name."
+  filename         = data.archive_file.catalog_describe.output_path
+  source_code_hash = data.archive_file.catalog_describe.output_base64sha256
+  handler          = "catalog_describe.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.catalog_describe_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE = aws_dynamodb_table.mesh_products.name
+      MESH_DOMAINS_TABLE  = aws_dynamodb_table.mesh_domains.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.catalog_describe]
+
+  tags = local.mandatory_tags
+}
+
+###############################################################################
+# ── Section 2: Subscription Lambdas ─────────────────────────────────────────
+###############################################################################
+
+# ── subscription_request ──────────────────────────────────────────────────────
+
+data "archive_file" "subscription_request" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/subscription_request.py"
+  output_path = "${path.module}/.build/subscription_request.zip"
+}
+
+resource "aws_cloudwatch_log_group" "subscription_request" {
+  name              = "/aws/lambda/mesh-subscription-request"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "subscription_request_lambda" {
+  name               = "MeshSubscriptionRequestLambdaRole"
+  description        = "Execution role for subscription_request Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "subscription_request_lambda" {
+  name = "MeshSubscriptionRequestLambdaPolicy"
+  role = aws_iam_role.subscription_request_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBWrite"
+        Effect = "Allow"
+        Action = ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"]
+        Resource = [
+          aws_dynamodb_table.mesh_subscriptions.arn,
+          "${aws_dynamodb_table.mesh_subscriptions.arn}/index/*",
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [aws_cloudwatch_event_bus.mesh_central.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-subscription-request:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "subscription_request" {
+  function_name    = "mesh-subscription-request"
+  description      = "Creates a new subscription request and emits SubscriptionRequested event."
+  filename         = data.archive_file.subscription_request.output_path
+  source_code_hash = data.archive_file.subscription_request.output_base64sha256
+  handler          = "subscription_request.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.subscription_request_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE      = aws_dynamodb_table.mesh_products.name
+      MESH_DOMAINS_TABLE       = aws_dynamodb_table.mesh_domains.name
+      MESH_SUBSCRIPTIONS_TABLE = aws_dynamodb_table.mesh_subscriptions.name
+      CENTRAL_EVENT_BUS_NAME   = aws_cloudwatch_event_bus.mesh_central.name
+      CENTRAL_ACCOUNT_ID       = data.aws_caller_identity.current.account_id
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.subscription_request]
+
+  tags = local.mandatory_tags
+}
+
+# ── subscription_provisioner ──────────────────────────────────────────────────
+
+data "archive_file" "subscription_provisioner" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/subscription_provisioner.py"
+  output_path = "${path.module}/.build/subscription_provisioner.zip"
+}
+
+resource "aws_cloudwatch_log_group" "subscription_provisioner" {
+  name              = "/aws/lambda/mesh-subscription-provisioner"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "subscription_provisioner_lambda" {
+  name               = "MeshSubscriptionProvisionerLambdaRole"
+  description        = "Execution role for subscription_provisioner Lambda (saga steps A/B/C)."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "subscription_provisioner_lambda" {
+  name = "MeshSubscriptionProvisionerLambdaPolicy"
+  role = aws_iam_role.subscription_provisioner_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBReadWrite"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:Query"]
+        Resource = [
+          aws_dynamodb_table.mesh_subscriptions.arn,
+          "${aws_dynamodb_table.mesh_subscriptions.arn}/index/*",
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "AssumeGrantorRoles"
+        Effect = "Allow"
+        Action = ["sts:AssumeRole"]
+        Resource = [
+          aws_iam_role.mesh_lf_grantor.arn,
+          aws_iam_role.mesh_kms_grantor.arn,
+          "arn:aws:iam::*:role/GlueConsumerRole"
+        ]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [aws_cloudwatch_event_bus.mesh_central.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-subscription-provisioner:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "subscription_provisioner" {
+  function_name    = "mesh-subscription-provisioner"
+  description      = "Saga steps A/B/C: LF grant, KMS grant, Glue resource link creation."
+  filename         = data.archive_file.subscription_provisioner.output_path
+  source_code_hash = data.archive_file.subscription_provisioner.output_base64sha256
+  handler          = "subscription_provisioner.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.subscription_provisioner_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE      = aws_dynamodb_table.mesh_products.name
+      MESH_SUBSCRIPTIONS_TABLE = aws_dynamodb_table.mesh_subscriptions.name
+      CENTRAL_EVENT_BUS_NAME   = aws_cloudwatch_event_bus.mesh_central.name
+      LF_GRANTOR_ROLE_ARN      = aws_iam_role.mesh_lf_grantor.arn
+      KMS_GRANTOR_ROLE_ARN     = aws_iam_role.mesh_kms_grantor.arn
+      CENTRAL_ACCOUNT_ID       = data.aws_caller_identity.current.account_id
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.subscription_provisioner]
+
+  tags = local.mandatory_tags
+}
+
+# Allow Step Functions to invoke subscription_provisioner
+resource "aws_lambda_permission" "sfn_subscription_provisioner" {
+  statement_id  = "AllowSFNInvokeSubscriptionProvisioner"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.subscription_provisioner.function_name
+  principal     = "states.amazonaws.com"
+  source_arn    = "arn:aws:states:${local.region}:${local.account_id}:stateMachine:subscription-provisioner"
+}
+
+# ── subscription_compensator ──────────────────────────────────────────────────
+
+data "archive_file" "subscription_compensator" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/subscription_compensator.py"
+  output_path = "${path.module}/.build/subscription_compensator.zip"
+}
+
+resource "aws_cloudwatch_log_group" "subscription_compensator" {
+  name              = "/aws/lambda/mesh-subscription-compensator"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "subscription_compensator_lambda" {
+  name               = "MeshSubscriptionCompensatorLambdaRole"
+  description        = "Execution role for subscription_compensator Lambda (saga rollback)."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "subscription_compensator_lambda" {
+  name = "MeshSubscriptionCompensatorLambdaPolicy"
+  role = aws_iam_role.subscription_compensator_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBReadWrite"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:UpdateItem", "dynamodb:Query"]
+        Resource = [
+          aws_dynamodb_table.mesh_subscriptions.arn,
+          "${aws_dynamodb_table.mesh_subscriptions.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "AssumeGrantorRoles"
+        Effect = "Allow"
+        Action = ["sts:AssumeRole"]
+        Resource = [
+          aws_iam_role.mesh_lf_grantor.arn,
+          aws_iam_role.mesh_kms_grantor.arn
+        ]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [aws_cloudwatch_event_bus.mesh_central.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-subscription-compensator:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "subscription_compensator" {
+  function_name    = "mesh-subscription-compensator"
+  description      = "Saga compensator: revokes partial LF/KMS grants and marks subscription FAILED."
+  filename         = data.archive_file.subscription_compensator.output_path
+  source_code_hash = data.archive_file.subscription_compensator.output_base64sha256
+  handler          = "subscription_compensator.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.subscription_compensator_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_SUBSCRIPTIONS_TABLE = aws_dynamodb_table.mesh_subscriptions.name
+      CENTRAL_EVENT_BUS_NAME   = aws_cloudwatch_event_bus.mesh_central.name
+      LF_GRANTOR_ROLE_ARN      = aws_iam_role.mesh_lf_grantor.arn
+      KMS_GRANTOR_ROLE_ARN     = aws_iam_role.mesh_kms_grantor.arn
+      CENTRAL_ACCOUNT_ID       = data.aws_caller_identity.current.account_id
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.subscription_compensator]
+
+  tags = local.mandatory_tags
+}
+
+# Allow Step Functions to invoke subscription_compensator
+resource "aws_lambda_permission" "sfn_subscription_compensator" {
+  statement_id  = "AllowSFNInvokeSubscriptionCompensator"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.subscription_compensator.function_name
+  principal     = "states.amazonaws.com"
+  source_arn    = "arn:aws:states:${local.region}:${local.account_id}:stateMachine:subscription-provisioner"
+}
+
+###############################################################################
+# ── Section 3: Event Handler Lambdas ────────────────────────────────────────
+###############################################################################
+
+# ── audit_writer ──────────────────────────────────────────────────────────────
+
+data "archive_file" "audit_writer" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/audit_writer.py"
+  output_path = "${path.module}/.build/audit_writer.zip"
+}
+
+resource "aws_cloudwatch_log_group" "audit_writer" {
+  name              = "/aws/lambda/mesh-audit-writer"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "audit_writer_lambda" {
+  name               = "MeshAuditWriterLambdaRole"
+  description        = "Execution role for audit_writer Lambda (append-only to audit log)."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "audit_writer_lambda" {
+  name = "MeshAuditWriterLambdaPolicy"
+  role = aws_iam_role.audit_writer_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AuditLogAppendOnly"
+        Effect   = "Allow"
+        Action   = ["dynamodb:PutItem"]
+        Resource = [aws_dynamodb_table.mesh_audit_log.arn]
+      },
+      {
+        Sid    = "ExplicitDenyAuditMutation"
+        Effect = "Deny"
+        Action = ["dynamodb:UpdateItem", "dynamodb:DeleteItem", "dynamodb:BatchWriteItem"]
+        Resource = [aws_dynamodb_table.mesh_audit_log.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-audit-writer:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "audit_writer" {
+  function_name    = "mesh-audit-writer"
+  description      = "Append-only audit log writer — PutItem to mesh-audit-log only."
+  filename         = data.archive_file.audit_writer.output_path
+  source_code_hash = data.archive_file.audit_writer.output_base64sha256
+  handler          = "audit_writer.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.audit_writer_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_AUDIT_LOG_TABLE = aws_dynamodb_table.mesh_audit_log.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.audit_writer]
+
+  tags = local.mandatory_tags
+}
+
+# Allow EventBridge to invoke audit_writer
+resource "aws_lambda_permission" "eventbridge_audit_writer" {
+  statement_id  = "AllowEventBridgeInvokeAuditWriter"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.audit_writer.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.all_events_audit.arn
+}
+
+# ── event_validator ───────────────────────────────────────────────────────────
+
+data "archive_file" "event_validator" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/event_validator.py"
+  output_path = "${path.module}/.build/event_validator.zip"
+}
+
+resource "aws_cloudwatch_log_group" "event_validator" {
+  name              = "/aws/lambda/mesh-event-validator"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "event_validator_lambda" {
+  name               = "MeshEventValidatorLambdaRole"
+  description        = "Execution role for event_validator Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "event_validator_lambda" {
+  name = "MeshEventValidatorLambdaPolicy"
+  role = aws_iam_role.event_validator_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBDedup"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:PutItem"]
+        Resource = [aws_dynamodb_table.mesh_event_dedup.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-event-validator:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "event_validator" {
+  function_name    = "mesh-event-validator"
+  description      = "Validates event sources and performs deduplication via mesh-event-dedup table."
+  filename         = data.archive_file.event_validator.output_path
+  source_code_hash = data.archive_file.event_validator.output_base64sha256
+  handler          = "event_validator.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.event_validator_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_EVENT_DEDUP_TABLE = aws_dynamodb_table.mesh_event_dedup.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.event_validator]
+
+  tags = local.mandatory_tags
+}
+
+# ── freshness_monitor ─────────────────────────────────────────────────────────
+
+data "archive_file" "freshness_monitor" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/freshness_monitor.py"
+  output_path = "${path.module}/.build/freshness_monitor.zip"
+}
+
+resource "aws_cloudwatch_log_group" "freshness_monitor" {
+  name              = "/aws/lambda/mesh-freshness-monitor"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "freshness_monitor_lambda" {
+  name               = "MeshFreshnessMonitorLambdaRole"
+  description        = "Execution role for freshness_monitor Lambda (daily cron)."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "freshness_monitor_lambda" {
+  name = "MeshFreshnessMonitorLambdaPolicy"
+  role = aws_iam_role.freshness_monitor_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBRead"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_quality_scores.arn,
+          "${aws_dynamodb_table.mesh_quality_scores.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [aws_cloudwatch_event_bus.mesh_central.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-freshness-monitor:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "freshness_monitor" {
+  function_name    = "mesh-freshness-monitor"
+  description      = "Daily cron: checks SLA freshness for all active products and emits FreshnessViolation events."
+  filename         = data.archive_file.freshness_monitor.output_path
+  source_code_hash = data.archive_file.freshness_monitor.output_base64sha256
+  handler          = "freshness_monitor.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.freshness_monitor_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE       = aws_dynamodb_table.mesh_products.name
+      MESH_QUALITY_SCORES_TABLE = aws_dynamodb_table.mesh_quality_scores.name
+      CENTRAL_EVENT_BUS_NAME    = aws_cloudwatch_event_bus.mesh_central.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.freshness_monitor]
+
+  tags = local.mandatory_tags
+}
+
+# Allow EventBridge Scheduler to invoke freshness_monitor
+resource "aws_lambda_permission" "scheduler_freshness_monitor" {
+  statement_id  = "AllowSchedulerInvokeFreshnessMonitor"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.freshness_monitor.function_name
+  principal     = "scheduler.amazonaws.com"
+  source_arn    = "arn:aws:scheduler:${local.region}:${local.account_id}:schedule/*"
+}
+
+###############################################################################
+# ── Section 4: Lifecycle Lambdas ─────────────────────────────────────────────
+###############################################################################
+
+# ── product_deprecation ───────────────────────────────────────────────────────
+
+data "archive_file" "product_deprecation" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/product_deprecation.py"
+  output_path = "${path.module}/.build/product_deprecation.zip"
+}
+
+resource "aws_cloudwatch_log_group" "product_deprecation" {
+  name              = "/aws/lambda/mesh-product-deprecation"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "product_deprecation_lambda" {
+  name               = "MeshProductDeprecationLambdaRole"
+  description        = "Execution role for product_deprecation Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "product_deprecation_lambda" {
+  name = "MeshProductDeprecationLambdaPolicy"
+  role = aws_iam_role.product_deprecation_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBReadWrite"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:UpdateItem", "dynamodb:Query"]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_subscriptions.arn,
+          "${aws_dynamodb_table.mesh_subscriptions.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [aws_cloudwatch_event_bus.mesh_central.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-product-deprecation:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "product_deprecation" {
+  function_name    = "mesh-product-deprecation"
+  description      = "Marks a data product as DEPRECATED and notifies active subscribers."
+  filename         = data.archive_file.product_deprecation.output_path
+  source_code_hash = data.archive_file.product_deprecation.output_base64sha256
+  handler          = "product_deprecation.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.product_deprecation_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE      = aws_dynamodb_table.mesh_products.name
+      MESH_SUBSCRIPTIONS_TABLE = aws_dynamodb_table.mesh_subscriptions.name
+      CENTRAL_EVENT_BUS_NAME   = aws_cloudwatch_event_bus.mesh_central.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.product_deprecation]
+
+  tags = local.mandatory_tags
+}
+
+# ── retirement ────────────────────────────────────────────────────────────────
+
+data "archive_file" "retirement" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/retirement.py"
+  output_path = "${path.module}/.build/retirement.zip"
+}
+
+resource "aws_cloudwatch_log_group" "retirement" {
+  name              = "/aws/lambda/mesh-retirement"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "retirement_lambda" {
+  name               = "MeshRetirementLambdaRole"
+  description        = "Execution role for retirement Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "retirement_lambda" {
+  name = "MeshRetirementLambdaPolicy"
+  role = aws_iam_role.retirement_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBReadWrite"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:UpdateItem", "dynamodb:Query", "dynamodb:Scan"]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_subscriptions.arn,
+          "${aws_dynamodb_table.mesh_subscriptions.arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "EventBridgePutEvents"
+        Effect = "Allow"
+        Action = ["events:PutEvents"]
+        Resource = [aws_cloudwatch_event_bus.mesh_central.arn]
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-retirement:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "retirement" {
+  function_name    = "mesh-retirement"
+  description      = "Retires a data product: revokes all active subscriptions and archives the product record."
+  filename         = data.archive_file.retirement.output_path
+  source_code_hash = data.archive_file.retirement.output_base64sha256
+  handler          = "retirement.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.retirement_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE      = aws_dynamodb_table.mesh_products.name
+      MESH_SUBSCRIPTIONS_TABLE = aws_dynamodb_table.mesh_subscriptions.name
+      CENTRAL_EVENT_BUS_NAME   = aws_cloudwatch_event_bus.mesh_central.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.retirement]
+
+  tags = local.mandatory_tags
+}
+
+###############################################################################
+# ── Section 5: Integration Stub ─────────────────────────────────────────────
+###############################################################################
+
+# ── datazone_connector ────────────────────────────────────────────────────────
+
+data "archive_file" "datazone_connector" {
+  type        = "zip"
+  source_file = "${path.root}/../../../lambdas/datazone_connector.py"
+  output_path = "${path.module}/.build/datazone_connector.zip"
+}
+
+resource "aws_cloudwatch_log_group" "datazone_connector" {
+  name              = "/aws/lambda/mesh-datazone-connector"
+  retention_in_days = 14
+  kms_key_id        = aws_kms_key.mesh_central.arn
+  tags              = local.mandatory_tags
+}
+
+resource "aws_iam_role" "datazone_connector_lambda" {
+  name               = "MeshDataZoneConnectorLambdaRole"
+  description        = "Execution role for datazone_connector Lambda."
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = local.mandatory_tags
+}
+
+resource "aws_iam_role_policy" "datazone_connector_lambda" {
+  name = "MeshDataZoneConnectorLambdaPolicy"
+  role = aws_iam_role.datazone_connector_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBRead"
+        Effect = "Allow"
+        Action = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"]
+        Resource = [
+          aws_dynamodb_table.mesh_products.arn,
+          "${aws_dynamodb_table.mesh_products.arn}/index/*",
+          aws_dynamodb_table.mesh_domains.arn
+        ]
+      },
+      {
+        Sid    = "DataZoneRead"
+        Effect = "Allow"
+        Action = [
+          "datazone:GetAsset",
+          "datazone:ListAssets",
+          "datazone:GetDomain",
+          "datazone:CreateAsset",
+          "datazone:UpdateAsset"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource = [aws_kms_key.mesh_central.arn]
+      },
+      {
+        Sid    = "Logging"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/mesh-datazone-connector:*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "datazone_connector" {
+  function_name    = "mesh-datazone-connector"
+  description      = "Integration stub: syncs mesh product catalog with AWS DataZone domain."
+  filename         = data.archive_file.datazone_connector.output_path
+  source_code_hash = data.archive_file.datazone_connector.output_base64sha256
+  handler          = "datazone_connector.handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.datazone_connector_lambda.arn
+  timeout          = 30
+  memory_size      = 256
+
+  environment {
+    variables = {
+      MESH_PRODUCTS_TABLE = aws_dynamodb_table.mesh_products.name
+      MESH_DOMAINS_TABLE  = aws_dynamodb_table.mesh_domains.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.datazone_connector]
+
+  tags = local.mandatory_tags
+}
+
+###############################################################################
+# API Gateway Lambda permissions (catalog routes)
+# The existing api_gateway.tf uses count guards on variables; now that Lambdas
+# exist in this module, we add direct permissions here. The api_gateway.tf
+# permissions based on variables remain for backward compat — these are
+# additional unconditional permissions wired to the real functions.
+###############################################################################
+
+resource "aws_lambda_permission" "apigw_catalog_writer" {
+  statement_id  = "AllowAPIGWInvokeCatalogWriter"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.catalog_writer.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "apigw_catalog_search_direct" {
+  statement_id  = "AllowAPIGWInvokeCatalogSearchDirect"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.catalog_search.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "apigw_catalog_browse_direct" {
+  statement_id  = "AllowAPIGWInvokeCatalogBrowseDirect"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.catalog_browse.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "apigw_catalog_describe_direct" {
+  statement_id  = "AllowAPIGWInvokeCatalogDescribeDirect"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.catalog_describe.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "apigw_subscription_request_direct" {
+  statement_id  = "AllowAPIGWInvokeSubscriptionRequestDirect"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.subscription_request.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.mesh_api.execution_arn}/*/*"
+}

--- a/infra/modules/governance/outputs.tf
+++ b/infra/modules/governance/outputs.tf
@@ -224,3 +224,77 @@ output "api_execution_arn" {
   description = "Execution ARN of the mesh governance API (used for Lambda permission source_arn)."
   value       = aws_apigatewayv2_api.mesh_api.execution_arn
 }
+
+###############################################################################
+# Lambda ARNs (Phase 6 — shared contracts for environments/central/main.tf)
+###############################################################################
+
+# Catalog Lambdas
+output "catalog_writer_lambda_arn" {
+  description = "ARN of the catalog_writer Lambda (handles ProductCreated / ProductRefreshed events)."
+  value       = aws_lambda_function.catalog_writer.arn
+}
+
+output "catalog_search_lambda_arn" {
+  description = "ARN of the catalog_search Lambda (GET /catalog/search)."
+  value       = aws_lambda_function.catalog_search.arn
+}
+
+output "catalog_browse_lambda_arn" {
+  description = "ARN of the catalog_browse Lambda (GET /catalog/browse)."
+  value       = aws_lambda_function.catalog_browse.arn
+}
+
+output "catalog_describe_lambda_arn" {
+  description = "ARN of the catalog_describe Lambda (GET /catalog/{domain}/{product})."
+  value       = aws_lambda_function.catalog_describe.arn
+}
+
+# Subscription Lambdas
+output "subscription_request_lambda_arn" {
+  description = "ARN of the subscription_request Lambda (POST /subscriptions)."
+  value       = aws_lambda_function.subscription_request.arn
+}
+
+output "subscription_provisioner_lambda_arn" {
+  description = "ARN of the subscription_provisioner Lambda (saga steps A/B/C — referenced by Step Functions)."
+  value       = aws_lambda_function.subscription_provisioner.arn
+}
+
+output "subscription_compensator_lambda_arn" {
+  description = "ARN of the subscription_compensator Lambda (saga rollback — referenced by Step Functions)."
+  value       = aws_lambda_function.subscription_compensator.arn
+}
+
+# Event handler Lambdas
+output "audit_writer_lambda_arn" {
+  description = "ARN of the audit_writer Lambda (append-only audit log writer)."
+  value       = aws_lambda_function.audit_writer.arn
+}
+
+output "event_validator_lambda_arn" {
+  description = "ARN of the event_validator Lambda (source validation and deduplication)."
+  value       = aws_lambda_function.event_validator.arn
+}
+
+output "freshness_monitor_lambda_arn" {
+  description = "ARN of the freshness_monitor Lambda (daily SLA freshness cron)."
+  value       = aws_lambda_function.freshness_monitor.arn
+}
+
+# Lifecycle Lambdas
+output "product_deprecation_lambda_arn" {
+  description = "ARN of the product_deprecation Lambda."
+  value       = aws_lambda_function.product_deprecation.arn
+}
+
+output "retirement_lambda_arn" {
+  description = "ARN of the retirement Lambda."
+  value       = aws_lambda_function.retirement.arn
+}
+
+# Integration stub
+output "datazone_connector_lambda_arn" {
+  description = "ARN of the datazone_connector Lambda (DataZone catalog sync stub)."
+  value       = aws_lambda_function.datazone_connector.arn
+}


### PR DESCRIPTION
Closes #38

## Summary
- Add `lambdas.tf` with all 14 `aws_lambda_function` resources (catalog_writer, catalog_search, catalog_browse, catalog_describe, subscription_request, subscription_provisioner, subscription_compensator, audit_writer, event_validator, freshness_monitor, product_deprecation, retirement, datazone_connector)
- Each Lambda has its own IAM execution role with least-privilege inline policy and a 14-day CloudWatch log group
- Wire ARNs into `api_gateway.tf` integration URIs — replaced variable-based `count` guards with direct `aws_lambda_function` references; integrations are now unconditional
- Export all 14 Lambda ARNs as module outputs in `outputs.tf` (shared contract for Stream 2)
- Replace empty-string Lambda ARN defaults in `environments/central/main.tf` — subscription module now receives `provisioner_lambda_arn` and `compensator_lambda_arn` from `module.governance` outputs

## Verification
`terraform init -backend=false && terraform validate` passes with zero errors on `infra/environments/central/`.