### PR TITLE
Phase 6 Stream 2: Guard Organizations-dependent Terraform + bootstrap docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ htmlcov/
 
 # Terraform Lambda build artifacts
 infra/modules/governance/.build/
+
+# Terraform local state files — never commit real account IDs or secrets
+infra/environments/central/terraform.tfvars
+infra/environments/**/.terraform/
+infra/environments/**/*.tfstate
+infra/environments/**/*.tfstate.backup

--- a/infra/environments/central/BOOTSTRAP.md
+++ b/infra/environments/central/BOOTSTRAP.md
@@ -1,0 +1,139 @@
+# Bootstrap: Central Governance Environment
+
+Run these steps **once** before `terraform init`. The S3 state bucket, DynamoDB
+lock table, and KMS key must exist before Terraform can initialise its backend
+(chicken-and-egg — you cannot use Terraform to create its own state store).
+
+Assumes you have the AWS CLI configured with credentials that have sufficient
+permissions in the central governance account (e.g. `AdministratorAccess`).
+
+---
+
+## 1. Export your central account ID
+
+```bash
+export CENTRAL_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo "Central account: $CENTRAL_ACCOUNT_ID"
+```
+
+---
+
+## 2. Create the KMS key and alias
+
+```bash
+KEY_ID=$(aws kms create-key \
+  --description "Data Meshy central Terraform state encryption key" \
+  --key-usage ENCRYPT_DECRYPT \
+  --query KeyMetadata.KeyId \
+  --output text)
+
+aws kms create-alias \
+  --alias-name alias/mesh-central \
+  --target-key-id "$KEY_ID"
+
+echo "KMS key: $KEY_ID  alias: alias/mesh-central"
+```
+
+---
+
+## 3. Create the S3 state bucket
+
+```bash
+aws s3api create-bucket \
+  --bucket "data-meshy-tfstate-central-${CENTRAL_ACCOUNT_ID}" \
+  --region us-east-1
+
+# Enable versioning
+aws s3api put-bucket-versioning \
+  --bucket "data-meshy-tfstate-central-${CENTRAL_ACCOUNT_ID}" \
+  --versioning-configuration Status=Enabled
+
+# Enable SSE-KMS default encryption
+aws s3api put-bucket-encryption \
+  --bucket "data-meshy-tfstate-central-${CENTRAL_ACCOUNT_ID}" \
+  --server-side-encryption-configuration '{
+    "Rules": [{
+      "ApplyServerSideEncryptionByDefault": {
+        "SSEAlgorithm": "aws:kms",
+        "KMSMasterKeyID": "alias/mesh-central"
+      },
+      "BucketKeyEnabled": true
+    }]
+  }'
+```
+
+---
+
+## 4. Block all public access on the state bucket
+
+```bash
+aws s3api put-public-access-block \
+  --bucket "data-meshy-tfstate-central-${CENTRAL_ACCOUNT_ID}" \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+```
+
+---
+
+## 5. Create the DynamoDB lock table
+
+```bash
+aws dynamodb create-table \
+  --table-name data-meshy-tflock-central \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region us-east-1
+```
+
+---
+
+## 6. Update backend.tf with your account ID
+
+Edit `infra/environments/central/backend.tf` and replace `CENTRAL_ACCOUNT_ID`
+with your real 12-digit account ID (the value of `$CENTRAL_ACCOUNT_ID`):
+
+```
+bucket = "data-meshy-tfstate-central-123456789012"
+```
+
+> Do NOT commit a real account ID in this file if the repo is public. The
+> placeholder `CENTRAL_ACCOUNT_ID` is intentional — replace it locally only.
+
+---
+
+## 7. Create terraform.tfvars
+
+```bash
+cp infra/environments/central/terraform.tfvars.example \
+   infra/environments/central/terraform.tfvars
+```
+
+Then edit `terraform.tfvars` and fill in:
+
+- `org_id` — your AWS Organization ID (e.g. `o-xxxxxxxxxx`). Leave as `""` if
+  Organizations is not yet set up (keep `organizations_enabled = false`).
+- `github_org` — your GitHub organisation or username.
+- `domain_account_ids` — list of domain account IDs (can be `[]` initially).
+
+> `terraform.tfvars` is listed in `.gitignore` — it will not be committed.
+
+---
+
+## 8. Run terraform init
+
+```bash
+cd infra/environments/central
+terraform init
+```
+
+---
+
+## After Organizations is set up
+
+Once AWS Organizations and IAM Identity Center are enabled:
+
+1. Set `organizations_enabled = true` in your `terraform.tfvars`.
+2. Set `org_id` to your Organization ID (e.g. `o-xxxxxxxxxx`).
+3. Run `terraform plan` then `terraform apply` to create the SCPs and
+   Identity Center permission sets.

--- a/infra/environments/central/backend.tf
+++ b/infra/environments/central/backend.tf
@@ -1,8 +1,10 @@
 terraform {
   backend "s3" {
     # Bucket name includes account_id to ensure global uniqueness.
-    # Replace <account_id> with your central governance AWS account ID.
-    bucket = "data-meshy-tfstate-central-<account_id>"
+    # Replace CENTRAL_ACCOUNT_ID below with your 12-digit AWS account ID.
+    # See BOOTSTRAP.md for step-by-step instructions to create this bucket
+    # and all other backend prerequisites before running terraform init.
+    bucket = "data-meshy-tfstate-central-CENTRAL_ACCOUNT_ID"
 
     key    = "central/terraform.tfstate"
     region = "us-east-1"

--- a/infra/environments/central/identity_center.tf
+++ b/infra/environments/central/identity_center.tf
@@ -5,12 +5,16 @@
 # applied from the management/central account with SSO enabled.
 #
 # Pre-requisite: IAM Identity Center must be enabled in the AWS Organization.
+# Guard: all resources are gated by var.organizations_enabled (default false).
+# Set organizations_enabled = true in terraform.tfvars after Organizations is set up.
 
-data "aws_ssoadmin_instances" "this" {}
+data "aws_ssoadmin_instances" "this" {
+  count = var.organizations_enabled ? 1 : 0
+}
 
 locals {
-  sso_instance_arn  = tolist(data.aws_ssoadmin_instances.this.arns)[0]
-  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+  sso_instance_arn  = var.organizations_enabled ? tolist(data.aws_ssoadmin_instances.this[0].arns)[0] : ""
+  identity_store_id = var.organizations_enabled ? tolist(data.aws_ssoadmin_instances.this[0].identity_store_ids)[0] : ""
 }
 
 ###############################################################################
@@ -19,6 +23,7 @@ locals {
 
 # MeshPlatformAdmin -> central: MeshAdminRole
 resource "aws_ssoadmin_permission_set" "mesh_platform_admin" {
+  count            = var.organizations_enabled ? 1 : 0
   name             = "MeshPlatformAdmin"
   description      = "Platform engineering access. Maps to MeshAdminRole in the central account. MFA required."
   instance_arn     = local.sso_instance_arn
@@ -32,8 +37,9 @@ resource "aws_ssoadmin_permission_set" "mesh_platform_admin" {
 }
 
 resource "aws_ssoadmin_permission_set_inline_policy" "mesh_platform_admin" {
+  count              = var.organizations_enabled ? 1 : 0
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = aws_ssoadmin_permission_set.mesh_platform_admin.arn
+  permission_set_arn = aws_ssoadmin_permission_set.mesh_platform_admin[0].arn
 
   inline_policy = jsonencode({
     Version = "2012-10-17"
@@ -50,6 +56,7 @@ resource "aws_ssoadmin_permission_set_inline_policy" "mesh_platform_admin" {
 
 # DomainAdmin -> domain: DomainAdminRole
 resource "aws_ssoadmin_permission_set" "domain_admin" {
+  count            = var.organizations_enabled ? 1 : 0
   name             = "DomainAdmin"
   description      = "Domain owner/admin access. Maps to DomainAdminRole in domain accounts."
   instance_arn     = local.sso_instance_arn
@@ -63,13 +70,15 @@ resource "aws_ssoadmin_permission_set" "domain_admin" {
 }
 
 resource "aws_ssoadmin_managed_policy_attachment" "domain_admin_read_only" {
+  count              = var.organizations_enabled ? 1 : 0
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = aws_ssoadmin_permission_set.domain_admin.arn
+  permission_set_arn = aws_ssoadmin_permission_set.domain_admin[0].arn
   managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
 # DomainDataEngineer -> domain: DomainDataEngineerRole
 resource "aws_ssoadmin_permission_set" "domain_data_engineer" {
+  count            = var.organizations_enabled ? 1 : 0
   name             = "DomainDataEngineer"
   description      = "Domain data engineer. Read/write S3, Glue jobs, catalog. Maps to DomainDataEngineerRole."
   instance_arn     = local.sso_instance_arn
@@ -84,6 +93,7 @@ resource "aws_ssoadmin_permission_set" "domain_data_engineer" {
 
 # DomainConsumer -> domain: DomainConsumerRole
 resource "aws_ssoadmin_permission_set" "domain_consumer" {
+  count            = var.organizations_enabled ? 1 : 0
   name             = "DomainConsumer"
   description      = "Read-only consumer access via LF grants and Athena. Maps to DomainConsumerRole."
   instance_arn     = local.sso_instance_arn
@@ -98,6 +108,7 @@ resource "aws_ssoadmin_permission_set" "domain_consumer" {
 
 # GovernanceViewer -> central: GovernanceReadRole
 resource "aws_ssoadmin_permission_set" "governance_viewer" {
+  count            = var.organizations_enabled ? 1 : 0
   name             = "GovernanceViewer"
   description      = "Governance team read-only access to all mesh metadata. Maps to GovernanceReadRole."
   instance_arn     = local.sso_instance_arn
@@ -111,8 +122,9 @@ resource "aws_ssoadmin_permission_set" "governance_viewer" {
 }
 
 resource "aws_ssoadmin_permission_set_inline_policy" "governance_viewer" {
+  count              = var.organizations_enabled ? 1 : 0
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = aws_ssoadmin_permission_set.governance_viewer.arn
+  permission_set_arn = aws_ssoadmin_permission_set.governance_viewer[0].arn
 
   inline_policy = jsonencode({
     Version = "2012-10-17"
@@ -132,30 +144,35 @@ resource "aws_ssoadmin_permission_set_inline_policy" "governance_viewer" {
 ###############################################################################
 
 resource "aws_identitystore_group" "platform_engineers" {
+  count             = var.organizations_enabled ? 1 : 0
   display_name      = "platform-engineers"
   description       = "Platform engineering team — MeshPlatformAdmin access to central account."
   identity_store_id = local.identity_store_id
 }
 
 resource "aws_identitystore_group" "sales_engineers" {
+  count             = var.organizations_enabled ? 1 : 0
   display_name      = "sales-engineers"
   description       = "Sales domain data engineers."
   identity_store_id = local.identity_store_id
 }
 
 resource "aws_identitystore_group" "sales_admins" {
+  count             = var.organizations_enabled ? 1 : 0
   display_name      = "sales-admins"
   description       = "Sales domain admins / product owners."
   identity_store_id = local.identity_store_id
 }
 
 resource "aws_identitystore_group" "marketing_analysts" {
+  count             = var.organizations_enabled ? 1 : 0
   display_name      = "marketing-analysts"
   description       = "Marketing domain consumers — read-only via Athena."
   identity_store_id = local.identity_store_id
 }
 
 resource "aws_identitystore_group" "governance_team" {
+  count             = var.organizations_enabled ? 1 : 0
   display_name      = "governance-team"
   description       = "Central governance / compliance team — GovernanceViewer access."
   identity_store_id = local.identity_store_id

--- a/infra/environments/central/main.tf
+++ b/infra/environments/central/main.tf
@@ -40,9 +40,21 @@ variable "environment" {
   default     = "portfolio"
 }
 
+variable "organizations_enabled" {
+  description = "Set to true once AWS Organizations and IAM Identity Center are enabled. Gates all Organizations-dependent resources (SCPs, Identity Center) so the central stack can be applied before the org is set up."
+  type        = bool
+  default     = false
+}
+
 variable "org_id" {
-  description = "AWS Organization ID."
+  description = "AWS Organization ID (o-xxxxxxxxxx). Required when organizations_enabled = true."
   type        = string
+  default     = ""
+
+  validation {
+    condition     = !var.organizations_enabled || length(var.org_id) > 0
+    error_message = "org_id must be set when organizations_enabled = true."
+  }
 }
 
 variable "domain_account_ids" {

--- a/infra/environments/central/scps.tf
+++ b/infra/environments/central/scps.tf
@@ -11,6 +11,7 @@
 # Domain OU SCP
 ###############################################################################
 resource "aws_organizations_policy" "domain_ou_guardrails" {
+  count       = var.organizations_enabled ? 1 : 0
   name        = "DataMeshyDomainGuardrails"
   description = "Data Meshy Domain OU guardrails: enforce security controls, cost guardrails, and governance compliance."
   type        = "SERVICE_CONTROL_POLICY"
@@ -174,6 +175,7 @@ resource "aws_organizations_policy" "domain_ou_guardrails" {
 # Platform OU SCP — require MFA for MeshAdminRole
 ###############################################################################
 resource "aws_organizations_policy" "platform_ou_guardrails" {
+  count       = var.organizations_enabled ? 1 : 0
   name        = "DataMeshyPlatformGuardrails"
   description = "Data Meshy Platform OU guardrails: MFA required for MeshAdminRole assumption."
   type        = "SERVICE_CONTROL_POLICY"

--- a/infra/environments/central/terraform.tfvars.example
+++ b/infra/environments/central/terraform.tfvars.example
@@ -1,0 +1,82 @@
+# terraform.tfvars.example
+#
+# Copy this file to terraform.tfvars and fill in real values before running
+# terraform init. See BOOTSTRAP.md for the full bootstrap sequence.
+#
+# terraform.tfvars is listed in .gitignore — do NOT commit it.
+
+###############################################################################
+# Core
+###############################################################################
+
+aws_region  = "us-east-1"
+environment = "portfolio"
+
+###############################################################################
+# Organizations — gate all SCPs and Identity Center resources
+###############################################################################
+
+# Set to false (default) until AWS Organizations + IAM Identity Center are
+# enabled in the central account. Flip to true and set org_id after setup.
+organizations_enabled = false
+
+# Required when organizations_enabled = true. Leave as "" otherwise.
+# Format: o-xxxxxxxxxx (10 alphanumeric characters after the "o-").
+org_id = ""
+
+###############################################################################
+# Domain accounts
+###############################################################################
+
+# List of 12-digit AWS account IDs for domain accounts that are allowed to
+# publish events to the central EventBridge bus.
+# Append-only — adding a domain never removes access for existing domains.
+# Example: domain_account_ids = ["123456789012", "210987654321"]
+domain_account_ids = []
+
+###############################################################################
+# GitHub OIDC
+###############################################################################
+
+# GitHub organisation or username that hosts the platform repo.
+github_org = "REPLACE_WITH_GITHUB_ORG"
+
+# GitHub repository name (default matches this repo).
+github_repo = "data-meshy"
+
+# OIDC subject conditions for domain GitHub repos.
+# Add one entry per domain repo as it is onboarded.
+# Example: domain_repo_paths = ["repo:my-org/data-meshy-sales:*"]
+domain_repo_paths = []
+
+###############################################################################
+# Alerting
+###############################################################################
+
+# Optional: email address to subscribe to SNS alert topics.
+# Leave as "" to skip email subscription.
+alert_email = ""
+
+###############################################################################
+# DataZone
+###############################################################################
+
+# Name of the AWS DataZone domain.
+datazone_domain_name = "data-meshy"
+
+# SSO type for DataZone. Use "DISABLED" for portfolio/dev deployments.
+# Set to "IAM_IDC" to enable IAM Identity Center integration for
+# non-technical product owner approval via the DataZone web UI.
+datazone_sso_type = "DISABLED"
+
+###############################################################################
+# Lambda ARN passthrough (backward compatibility — not passed to modules)
+###############################################################################
+# These variables are kept for compatibility with older tfvars files.
+# Lambdas are now created directly inside the governance module (Phase 6).
+# Leave as "" — values here have no effect.
+
+subscription_provisioner_lambda_arn = ""
+subscription_compensator_lambda_arn = ""
+subscription_approver_lambda_arn    = ""
+subscription_lister_lambda_arn      = ""


### PR DESCRIPTION
Closes #39
Closes #40

## Summary
- `organizations_enabled` variable (default `false`) guards all Organizations-dependent resources in `identity_center.tf` and `scps.tf`
- `org_id` gets default `""` with a validation block that only rejects empty when `organizations_enabled = true`
- All resources and data sources in `identity_center.tf` wrapped with `count = var.organizations_enabled ? 1 : 0`; locals use `[0]` indexing
- Both policy resources in `scps.tf` wrapped with `count = var.organizations_enabled ? 1 : 0`
- `backend.tf` placeholder replaced with `CENTRAL_ACCOUNT_ID` comment referencing `BOOTSTRAP.md`
- `BOOTSTRAP.md` created with copy-paste CLI commands for KMS key, S3 state bucket, DynamoDB lock table
- `terraform.tfvars.example` created with all variables from `main.tf`
- `infra/environments/central/terraform.tfvars` added to `.gitignore`

## Verification
`terraform init -backend=false && terraform validate` passes with zero errors on `infra/environments/central/`