### PR TITLE
fix: org_id variable validation cross-reference

### DIFF
--- a/infra/environments/central/main.tf
+++ b/infra/environments/central/main.tf
@@ -47,13 +47,13 @@ variable "organizations_enabled" {
 }
 
 variable "org_id" {
-  description = "AWS Organization ID (o-xxxxxxxxxx). Required when organizations_enabled = true."
+  description = "AWS Organization ID (o-xxxxxxxxxx). Required when organizations_enabled = true. Leave empty when organizations_enabled = false."
   type        = string
   default     = ""
 
   validation {
-    condition     = !var.organizations_enabled || length(var.org_id) > 0
-    error_message = "org_id must be set when organizations_enabled = true."
+    condition     = var.org_id == "" || can(regex("^o-[a-z0-9]{10,32}$", var.org_id))
+    error_message = "org_id must be empty or a valid AWS Organization ID (o-xxxxxxxxxx)."
   }
 }
 


### PR DESCRIPTION
## Summary

- Terraform does not allow variable `validation` blocks to reference other variables — only `var.<itself>` is permitted
- `org_id` had `condition = !var.organizations_enabled || length(var.org_id) > 0` which caused `terraform plan` to fail with *Invalid reference in variable validation*
- Replaced with a format check: empty string OR matches `o-[a-z0-9]{10,32}` pattern
- The `organizations_enabled` enforcement already exists at resource level via `count = var.organizations_enabled ? 1 : 0`

## Test plan
- [ ] `terraform validate` passes on `infra/environments/central`
- [ ] `terraform plan` no longer errors on variable validation
- [ ] Setting `org_id = "not-valid"` correctly triggers the new error message

Fixes: Terraform Plan CI failure on PR #48 branch (discovered 2026-05-25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)