### PR TITLE
fix: read MESH_API_ENDPOINT from secrets in onboard-domain.yml

### DIFF
--- a/.github/workflows/onboard-domain.yml
+++ b/.github/workflows/onboard-domain.yml
@@ -536,7 +536,7 @@ jobs:
           set -euo pipefail
 
           TARGET="JawaharRamis/${NEW_REPO}"
-          MESH_API_ENDPOINT="${{ vars.MESH_API_ENDPOINT }}"
+          MESH_API_ENDPOINT="${{ secrets.MESH_API_ENDPOINT }}"
 
           echo "${DOMAIN_ROLE_ARN}" | gh secret set AWS_ROLE_ARN      --repo "${TARGET}"
           echo "${MESH_API_ENDPOINT}" | gh secret set MESH_API_ENDPOINT --repo "${TARGET}"


### PR DESCRIPTION
## Summary
- `vars.MESH_API_ENDPOINT` was silently empty — the value is stored as a secret, not a variable
- Without this fix, `sales-products` repo would get a blank `MESH_API_ENDPOINT` secret

## Test plan
- [ ] Merge this before triggering `onboard-domain.yml` for the sales domain
- [ ] After workflow runs, verify `MESH_API_ENDPOINT` secret on `sales-products` repo is non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)